### PR TITLE
refactor: split app.js into focused modules (appsplit → dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-## Branch Hierarchy & Merge Order
-
-> **This is the `appsplit` branch** — branched from `dev`. Splits `app.js` into focused modules.
->
-> ```
-> main
-> └── dev
->     └── appsplit    ← YOU ARE HERE
-> ```
->
-> **Merge order:** `appsplit` → `dev` → `main`
-
 # Bible Reader
 
 A fast, offline-capable Bible reading app built with vanilla JavaScript, served via GitHub Pages.
@@ -45,6 +33,7 @@ A fast, offline-capable Bible reading app built with vanilla JavaScript, served 
 ├── bible-structure.js      # Book/chapter/testament lookup tables
 ├── bsb-structure.js        # Heading/paragraph scaffold loader (BSB)
 ├── ui.js                   # Theme, element caching, icon updates
+├── firebase-config.js      # Root stub — re-exports from config/firebase-config.js
 ├── sw.js                   # Service worker
 ├── styles.css              # All styles
 ├── cross_references.txt    # Cross-reference source data (8 MB)
@@ -56,6 +45,7 @@ A fast, offline-capable Bible reading app built with vanilla JavaScript, served 
 ├── data/
 │   ├── bsb-usfm/           # BSB USFM source files (67 books)
 │   └── known_absent_verses.json
+├── js/                     # Additional JS modules
 ├── translations/           # Per-translation Bible JSON files
 ├── scripts/                # Build and conversion scripts
 ├── tests/                  # Unit (Vitest) and E2E (Playwright) tests

--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
 ## Branch Hierarchy & Merge Order
 
-> **This is the `search` branch** — branched from `dev`. Contains the full-text search feature.
+> **This is the `appsplit` branch** — branched from `dev`. Splits `app.js` into focused modules.
 >
 > ```
 > main
 > └── dev
->     └── search                  ← YOU ARE HERE
->         └── refactor/split-app-js  ← breaks app.js into modules; merges into search
+>     └── appsplit    ← YOU ARE HERE
 > ```
 >
-> **Merge order (bottom-up):**
-> 1. `refactor/split-app-js` → `search`
-> 2. `search` → `dev`
-> 3. `dev` → `main`
->
-> Do not skip steps or merge out of order. Complete and merge `refactor/split-app-js` into this branch before merging `search` into `dev`.
+> **Merge order:** `appsplit` → `dev` → `main`
 
 # Bible Reader
 
@@ -38,12 +32,19 @@ A fast, offline-capable Bible reading app built with vanilla JavaScript, served 
 ```
 /
 ├── index.html              # App entry point
-├── app.js                  # Main app logic and BibleApp class
+├── app.js                  # Orchestrator: init, loadPassage, delegation, SW registration
+├── events.js               # All DOM event listener wiring (attachEventListeners)
+├── keyboard.js             # Global keyboard shortcut handler
+├── modals.js               # Modal open/close, book/chapter/verse population, drag-to-resize
+├── settings.js             # Load, apply, and persist user preferences
+├── auth.js                 # Firebase auth, login/signup/logout, reading position persistence
+├── search.js               # Full-text and passage-reference search
+├── navigation.js           # Prev/next chapter and verse button logic
+├── reading-state.js        # State initialisation, chapter nav, verse scroll/glow
 ├── bible-api.js            # Translation loader and passage renderer
+├── bible-structure.js      # Book/chapter/testament lookup tables
 ├── bsb-structure.js        # Heading/paragraph scaffold loader (BSB)
-├── reading-state.js        # Navigation and settings state
-├── ui.js                   # Theme, UI utilities, and element caching
-├── firebase-config.js      # Root stub (redirects to config/)
+├── ui.js                   # Theme, element caching, icon updates
 ├── sw.js                   # Service worker
 ├── styles.css              # All styles
 ├── cross_references.txt    # Cross-reference source data (8 MB)
@@ -54,13 +55,32 @@ A fast, offline-capable Bible reading app built with vanilla JavaScript, served 
 │   └── firebase-config.js  # Firebase init and exports (auth, db, config)
 ├── data/
 │   ├── bsb-usfm/           # BSB USFM source files (67 books)
-│   └── known_absent_verses.json  # Per-translation list of TR-absent verses
-├── js/                     # Additional JS modules
+│   └── known_absent_verses.json
 ├── translations/           # Per-translation Bible JSON files
 ├── scripts/                # Build and conversion scripts
 ├── tests/                  # Unit (Vitest) and E2E (Playwright) tests
 └── docs/                   # Project documentation
 ```
+
+## Architecture
+
+`app.js` is a thin orchestrator. It owns `init`, `loadPassage`, the service-worker helpers, and one-liner delegation methods for everything else. It should only change when you are modifying the app lifecycle or how passages are loaded.
+
+All other logic lives in single-responsibility modules. When adding a feature, touch only the modules relevant to that feature:
+
+| What you're adding | Files to touch |
+|---|---|
+| New user preference / setting | `settings.js` + `events.js` (one new toggle binding) |
+| New modal | `modals.js` + `events.js` (open/close/populate + binding) |
+| New keyboard shortcut | `keyboard.js` only |
+| New auth behaviour | `auth.js` only |
+| New event binding (button, toggle, etc.) | `events.js` only |
+| New API call or passage rendering change | `bible-api.js` or `reading-state.js` |
+| New search capability | `search.js` + `events.js` if it needs a new trigger |
+| New lifecycle step at startup | `app.js` (`init`) |
+| Change to how passages load | `app.js` (`loadPassage`) |
+
+`app.js` itself should not grow. If you find yourself adding logic directly to `app.js`, it belongs in one of the modules above instead.
 
 ## Firebase Setup
 

--- a/app.js
+++ b/app.js
@@ -30,6 +30,26 @@ import {
     navigateToNextVerse,
     navigateToPreviousVerse,
 } from './navigation.js';
+import {
+    toggleSearch,
+    closeSearch,
+    handleSearch,
+    handleSearchKeydown,
+    refreshSearchResultItems,
+    setSearchSelectedIndex,
+    activateSelectedSearchResult,
+    isPassageReference,
+    handlePassageReference,
+    fetchAllSearchResults,
+    groupSearchResultsByCanon,
+    performKeywordSearch,
+    displaySearchResults,
+    parseReference,
+    loadPassageFromReference,
+    escapeRegExp,
+    highlightSearchTerm,
+    stripHTML,
+} from './search.js';
 
 function readBool(key, defaultValue) {
     try {
@@ -687,387 +707,27 @@ class BibleApp {
     }
 
     // ================================
-    // Search
+    // Search (delegated)
     // ================================
 
-    toggleSearch() {
-        this.searchContainer.classList.toggle('active');
-        if (this.searchContainer.classList.contains('active')) {
-            this.searchInput.focus();
-        } else {
-            this.searchInput.value = '';
-            this.searchResults.innerHTML = '';
-            this.searchSelectedIndex = -1;
-            this.searchResultItems = [];
-        }
-    }
-
-    closeSearch() {
-        this.searchContainer.classList.remove('active');
-        this.searchInput.value = '';
-        this.searchResults.innerHTML = '';
-        this.searchSelectedIndex = -1;
-        this.searchResultItems = [];
-    }
-
-    handleSearch(query) {
-        clearTimeout(this.searchTimeout);
-        this.searchLastQuery = query;
-        this.currentSearchResults = [];
-
-        if (!query.trim()) {
-            this.searchResults.innerHTML = '';
-            this.searchSelectedIndex = -1;
-            this.searchResultItems = null;
-            return;
-        }
-
-        this.searchTimeout = setTimeout(async () => {
-            if (this.isPassageReference(query)) {
-                await this.handlePassageReference(query);
-            } else {
-                await this.performKeywordSearch(query);
-            }
-        }, 300);
-    }
-
-    handleSearchKeydown(e) {
-        if (e.key === 'Escape') {
-            e.preventDefault();
-            this.closeSearch();
-            return;
-        }
-
-        if (!this.searchResultItems || this.searchResultItems.length === 0) return;
-
-        if (e.key === 'ArrowDown') {
-            e.preventDefault();
-            this.setSearchSelectedIndex(Math.min(this.searchSelectedIndex + 1, this.searchResultItems.length - 1), true);
-            return;
-        }
-
-        if (e.key === 'ArrowUp') {
-            e.preventDefault();
-            this.setSearchSelectedIndex(Math.max(this.searchSelectedIndex - 1, 0), true);
-            return;
-        }
-
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            this.activateSelectedSearchResult();
-        }
-    }
-
-    refreshSearchResultItems(autoSelectFirst = false) {
-        this.searchResultItems = Array.from(
-            this.searchResults.querySelectorAll('.search-result-item')
-        );
-
-        if (!this.searchResultItems.length) {
-            this.searchSelectedIndex = -1;
-            return;
-        }
-
-        if (autoSelectFirst) {
-            this.setSearchSelectedIndex(0, false);
-        } else {
-            if (this.searchSelectedIndex < 0 || this.searchSelectedIndex >= this.searchResultItems.length) {
-                this.searchSelectedIndex = -1;
-            } else {
-                this.setSearchSelectedIndex(this.searchSelectedIndex, false);
-            }
-        }
-    }
-
-    setSearchSelectedIndex(index, scrollIntoView = false) {
-        if (!this.searchResultItems || this.searchResultItems.length === 0) {
-            this.searchSelectedIndex = -1;
-            return;
-        }
-
-        const clamped = Math.max(0, Math.min(index, this.searchResultItems.length - 1));
-        this.searchSelectedIndex = clamped;
-
-        this.searchResultItems.forEach((el, i) => {
-            el.classList.toggle('selected', i === clamped);
-        });
-
-        if (scrollIntoView) {
-            this.searchResultItems[clamped]?.scrollIntoView({ block: 'nearest' });
-        }
-    }
-
-    activateSelectedSearchResult() {
-        if (!this.searchResultItems || this.searchSelectedIndex < 0 || this.searchSelectedIndex >= this.searchResultItems.length) return;
-        this.searchResultItems[this.searchSelectedIndex]?.click();
-    }
-
-    isPassageReference(query) {
-        const patterns = [
-            /^[1-3]?\s*[a-z]+\s+\d+/i,
-            /^[1-3]?\s*[a-z]+\s+\d+:\d+/i,
-        ];
-        return patterns.some((p) => p.test(query.trim()));
-    }
-
-    async handlePassageReference(reference) {
-        const data = await this.bibleApi.fetchPassage(reference);
-
-        if (data && data.passages && data.passages.length > 0) {
-            const safeCanonical = String(data.canonical || '').replace(/"/g, '&quot;');
-            const preview = this.stripHTML(data.passages[0]).substring(0, 200);
-
-            this.searchResults.innerHTML =
-                '<div class="search-result-item" data-reference="' + safeCanonical + '">' +
-                '<div class="search-result-reference">' + safeCanonical + '</div>' +
-                '<div class="search-result-content">' + preview + '...</div>' +
-                '</div>';
-
-            const item = this.searchResults.querySelector('.search-result-item');
-            if (item) {
-                item.addEventListener('click', async () => {
-                    await this.loadPassageFromReference(item.dataset.reference);
-                    this.closeSearch();
-                });
-            }
-
-            this.refreshSearchResultItems(true);
-        } else {
-            this.searchResults.innerHTML = '<div class="search-no-results">No passage found</div>';
-            this.refreshSearchResultItems(false);
-        }
-    }
-
-    async fetchAllSearchResults(query, onBatch) {
-        this.currentSearchResults = [];
-        await this.bibleApi.searchPassages(query, (batchResults) => {
-            this.currentSearchResults.push(...batchResults);
-            if (typeof onBatch === 'function') onBatch(this.currentSearchResults.slice());
-        });
-        return this.currentSearchResults;
-    }
-
-    groupSearchResultsByCanon(results) {
-        if (!Array.isArray(results)) return [];
-
-        const otBooks = Object.keys(this.bibleBooks['Old Testament']);
-        const ntBooks = Object.keys(this.bibleBooks['New Testament']);
-        const otGroups = new Map();
-        const ntGroups = new Map();
-
-        for (const result of results) {
-            const parsed = this.parseReference?.(result.reference);
-            if (!parsed) continue;
-            const { book } = parsed;
-            const testament = this.getTestament?.(book);
-
-            if (testament === 'Old Testament') {
-                if (!otGroups.has(book)) otGroups.set(book, []);
-                otGroups.get(book).push(result);
-            } else if (testament === 'New Testament') {
-                if (!ntGroups.has(book)) ntGroups.set(book, []);
-                ntGroups.get(book).push(result);
-            }
-        }
-
-        const grouped = [];
-
-        if (otGroups.size) {
-            grouped.push({
-                heading: 'Old Testament',
-                books: otBooks.filter((b) => otGroups.has(b)).map((book) => ({ book, results: otGroups.get(book) })),
-            });
-        }
-
-        if (ntGroups.size) {
-            grouped.push({
-                heading: 'New Testament',
-                books: ntBooks.filter((b) => ntGroups.has(b)).map((book) => ({ book, results: ntGroups.get(book) })),
-            });
-        }
-
-        return grouped;
-    }
-
-    async performKeywordSearch(query) {
-        this.searchResults.innerHTML = '<div class="loading" style="min-height: 100px">Searching...</div>';
-        this.searchSelectedIndex = -1;
-        this.searchResultItems = [];
-
-        this.searchExpandedTestaments?.clear();
-        this.searchExpandedBooks?.clear();
-
-        await this.fetchAllSearchResults(query, (accumulatedResults) => {
-            if (accumulatedResults.length > 0) {
-                this.displaySearchResults(accumulatedResults, query);
-            }
-        });
-
-        if (this.currentSearchResults.length > 0) {
-            this.displaySearchResults(this.currentSearchResults, query);
-        } else {
-            this.searchResults.innerHTML = '<div class="search-no-results">No results found</div>';
-            this.refreshSearchResultItems(false);
-        }
-    }
-
-    displaySearchResults(results, query) {
-        const groups = this.groupSearchResultsByCanon(results);
-
-        if (!groups.length) {
-            this.searchResults.innerHTML = '<div class="search-no-results">No results found</div>';
-            this.refreshSearchResultItems(false);
-            return;
-        }
-
-        if (this.searchExpandedTestaments.size === 0 && this.searchExpandedBooks.size === 0) {
-            const firstGroup = groups[0];
-            if (firstGroup) {
-                this.searchExpandedTestaments.add(firstGroup.heading);
-                const firstBook = firstGroup.books && firstGroup.books[0];
-                if (firstBook) this.searchExpandedBooks.add(firstBook.book);
-            }
-        }
-
-        const esc = (str) =>
-            String(str || '')
-                .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-
-        const parts = [];
-
-        for (const group of groups) {
-            const testName = group.heading;
-            const testamentExpanded = this.searchExpandedTestaments.has(testName);
-
-            parts.push(`
-      <div class="search-group-heading" data-testament="${esc(testName)}">
-        <span class="search-group-title">${esc(testName)}</span>
-        <span class="search-group-chevron ${testamentExpanded ? 'expanded' : ''}">&#9662;</span>
-      </div>
-    `);
-
-            if (!testamentExpanded) continue;
-
-            for (const bookBlock of group.books) {
-                const bookName = bookBlock.book;
-                const bookExpanded = this.searchExpandedBooks.has(bookName);
-
-                parts.push(`
-        <div class="search-book-heading" data-book="${esc(bookName)}">
-          <span class="search-book-title">${esc(this.getDisplayName(bookName))}</span>
-          <span class="search-book-chevron ${bookExpanded ? 'expanded' : ''}">&#9662;</span>
-        </div>
-      `);
-
-                if (!bookExpanded) continue;
-
-                for (const result of bookBlock.results) {
-                    let highlighted = result.content;
-                    try {
-                        highlighted = this.highlightSearchTerm(result.content, query);
-                    } catch (err) {
-                        console.warn('highlight failed', err);
-                    }
-
-                    parts.push(`
-          <div class="search-result-item" data-reference="${esc(result.reference)}">
-            <div class="search-result-reference">${esc(result.reference)}</div>
-            <div class="search-result-content">${highlighted}</div>
-          </div>
-        `);
-                }
-            }
-        }
-
-        this.searchResults.innerHTML = parts.join('');
-
-        this.searchResults.querySelectorAll('.search-group-heading').forEach((el) => {
-            el.addEventListener('click', () => {
-                const testament = el.getAttribute('data-testament');
-                if (!testament) return;
-                if (this.searchExpandedTestaments.has(testament)) {
-                    this.searchExpandedTestaments.delete(testament);
-                } else {
-                    this.searchExpandedTestaments.add(testament);
-                }
-                this.displaySearchResults(results, query);
-            });
-        });
-
-        this.searchResults.querySelectorAll('.search-book-heading').forEach((el) => {
-            el.addEventListener('click', () => {
-                const book = el.getAttribute('data-book');
-                if (!book) return;
-                if (this.searchExpandedBooks.has(book)) {
-                    this.searchExpandedBooks.delete(book);
-                } else {
-                    this.searchExpandedBooks.add(book);
-                }
-                this.displaySearchResults(results, query);
-            });
-        });
-
-        this.searchResults.querySelectorAll('.search-result-item').forEach((item) => {
-            item.addEventListener('click', async () => {
-                await this.loadPassageFromReference(item.dataset.reference);
-                this.closeSearch();
-            });
-        });
-
-        this.refreshSearchResultItems(true);
-    }
-
-    parseReference(reference) {
-        const cleaned = String(reference || '').trim();
-        const match = cleaned.match(/^((?:\d\s+)?[A-Za-z][A-Za-z ]*?)\s+(\d+)(?::(\d+))?$/);
-        if (!match) return null;
-
-        const book = match[1].trim();
-        const chapter = parseInt(match[2], 10);
-        const verse = match[3] ? parseInt(match[3], 10) : null;
-
-        if (!book || !Number.isFinite(chapter)) return null;
-        if (verse !== null && !Number.isFinite(verse)) return null;
-
-        return { book, chapter, verse };
-    }
-
-    async loadPassageFromReference(reference) {
-        const parsed = this.parseReference(reference);
-        if (!parsed) return;
-
-        const { book, chapter, verse } = parsed;
-        this.state.selectedVerse = verse || null;
-        await this.loadPassage(book, chapter);
-
-        if (verse) this.scrollToVerse(verse);
-    }
-
-    escapeRegExp(str) {
-        return String(str).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    }
-
-    highlightSearchTerm(text, term) {
-        if (text == null) return '';
-        const safeText = String(text);
-        const rawTerm = term == null ? '' : String(term).trim();
-        if (!rawTerm) return safeText;
-
-        try {
-            const regex = new RegExp(this.escapeRegExp(rawTerm), 'gi');
-            return safeText.replace(regex, (match) => `<strong>${match}</strong>`);
-        } catch (err) {
-            console.warn('highlightSearchTerm failed', err);
-            return safeText;
-        }
-    }
-
-    stripHTML(html) {
-        const tmp = document.createElement('div');
-        tmp.innerHTML = html;
-        return tmp.textContent || tmp.innerText || '';
-    }
+    toggleSearch() { toggleSearch(this); }
+    closeSearch() { closeSearch(this); }
+    handleSearch(query) { handleSearch(this, query); }
+    handleSearchKeydown(e) { handleSearchKeydown(this, e); }
+    refreshSearchResultItems(autoSelectFirst) { refreshSearchResultItems(this, autoSelectFirst); }
+    setSearchSelectedIndex(index, scrollIntoView) { setSearchSelectedIndex(this, index, scrollIntoView); }
+    activateSelectedSearchResult() { activateSelectedSearchResult(this); }
+    isPassageReference(query) { return isPassageReference(query); }
+    async handlePassageReference(reference) { await handlePassageReference(this, reference); }
+    async fetchAllSearchResults(query, onBatch) { return fetchAllSearchResults(this, query, onBatch); }
+    groupSearchResultsByCanon(results) { return groupSearchResultsByCanon(this, results); }
+    async performKeywordSearch(query) { await performKeywordSearch(this, query); }
+    displaySearchResults(results, query) { displaySearchResults(this, results, query); }
+    parseReference(reference) { return parseReference(reference); }
+    async loadPassageFromReference(reference) { await loadPassageFromReference(this, reference); }
+    escapeRegExp(str) { return escapeRegExp(str); }
+    highlightSearchTerm(text, term) { return highlightSearchTerm(text, term); }
+    stripHTML(html) { return stripHTML(html); }
 
     // ================================
     // Modals

--- a/app.js
+++ b/app.js
@@ -10,7 +10,6 @@ import {
     scrollToVerse as scrollVerse,
     applyVerseGlow as glowVerse,
 } from './reading-state.js';
-import { loadUserData as loadUserDataFromFirebase } from './config/firebase-config.js';
 import {
     cacheElements,
     loadTheme,
@@ -50,6 +49,17 @@ import {
     highlightSearchTerm,
     stripHTML,
 } from './search.js';
+import {
+    loadSavedPositionIfChanged,
+    loadSavedReadingPosition,
+    saveReadingPosition,
+    checkApiKey,
+    handleUserButtonClick,
+    handleLogin,
+    handleSignup,
+    handleLogout,
+    loadUserData,
+} from './auth.js';
 
 function readBool(key, defaultValue) {
     try {
@@ -543,85 +553,16 @@ class BibleApp {
     // ==========================================
 
     async _loadSavedPositionIfChanged() {
-        if (!this.currentUser || !this.database) return;
-
-        let targetBook = this.state.currentBook;
-        let targetChapter = this.state.currentChapter;
-        let targetScrollY = 0;
-
-        try {
-            const snapshot = await withTimeout(
-                this.database.ref(`users/${this.currentUser.uid}/readingPosition`).once('value'),
-                5000
-            );
-
-            if (snapshot) {
-                const pos = snapshot.val();
-                if (pos && pos.book && pos.chapter) {
-                    targetBook = pos.book;
-                    targetChapter = pos.chapter;
-                    targetScrollY = pos.scrollY || 0;
-                }
-            } else {
-                console.warn('_loadSavedPositionIfChanged: timed out, keeping current passage');
-            }
-        } catch (err) {
-            console.error('_loadSavedPositionIfChanged: Firebase read failed', err);
-        }
-
-        if (targetBook !== this.state.currentBook || targetChapter !== this.state.currentChapter) {
-            this.state.currentBook = targetBook;
-            this.state.currentChapter = targetChapter;
-            this.lastScrollPosition = targetScrollY;
-            await this.loadPassage(targetBook, targetChapter, !!targetScrollY);
-        } else if (targetScrollY) {
-            window.scrollTo(0, targetScrollY);
-        }
+        await loadSavedPositionIfChanged(this, withTimeout);
     }
 
     /** @deprecated Use _loadSavedPositionIfChanged for the auth flow. */
     async loadSavedReadingPosition() {
-        if (!this.currentUser || !this.database) {
-            await this.loadPassage(this.state.currentBook, this.state.currentChapter);
-            return;
-        }
-
-        try {
-            const snapshot = await withTimeout(
-                this.database.ref(`users/${this.currentUser.uid}/readingPosition`).once('value'),
-                5000
-            );
-
-            if (snapshot) {
-                const pos = snapshot.val();
-                if (pos && pos.book && pos.chapter) {
-                    this.state.currentBook = pos.book;
-                    this.state.currentChapter = pos.chapter;
-                    this.lastScrollPosition = pos.scrollY || 0;
-                }
-            } else {
-                console.warn('loadSavedReadingPosition: timed out, loading from local state');
-            }
-        } catch (err) {
-            console.error('loadSavedReadingPosition: failed to read Firebase', err);
-        }
-
-        await this.loadPassage(this.state.currentBook, this.state.currentChapter, !!this.lastScrollPosition);
+        await loadSavedReadingPosition(this, withTimeout);
     }
 
     saveReadingPosition() {
-        if (!this.currentUser || !this.database) return;
-
-        const pos = {
-            book: this.state.currentBook,
-            chapter: this.state.currentChapter,
-            scrollY: window.scrollY || 0,
-        };
-
-        this.database
-            .ref(`users/${this.currentUser.uid}/readingPosition`)
-            .set(pos)
-            .catch((err) => console.error('saveReadingPosition: Firebase write failed', err));
+        saveReadingPosition(this);
     }
 
     async loadPassage(book, chapter, restoreScroll = false) {
@@ -857,9 +798,7 @@ class BibleApp {
     // ================================
 
     checkApiKey() {
-        setTimeout(() => {
-            this.showToast('Sign in to sync your reading position across devices.');
-        }, 500);
+        checkApiKey(this);
     }
 
     loadLocalSettings() {
@@ -1056,124 +995,23 @@ class BibleApp {
     // ================================
 
     handleUserButtonClick() {
-        if (this.currentUser) {
-            document.getElementById('userEmail').textContent = this.currentUser.email;
-            const isLight = document.body.classList.contains('light-mode');
-            let colorTheme = this.state?.colorTheme || 'dracula';
-
-            try { colorTheme = this.state?.colorTheme || localStorage.getItem('colorTheme') || 'dracula'; } catch (_) {}
-            const themeNameMap = {
-                dracula: isLight ? 'Alucard (Light)' : 'Dracula (Dark)',
-                steel:   `Steel (${isLight ? 'Light' : 'Dark'})`,
-                onyx:    `Onyx (${isLight ? 'Light' : 'Dark'})`,
-                reader:  `Reader (${isLight ? 'Parchment' : 'Night'})`,
-            };
-            document.getElementById('userTheme').textContent =
-                themeNameMap[colorTheme] || (isLight ? 'Alucard (Light)' : 'Dracula (Dark)');
-            this.openModal(this.userMenuModal);
-        } else {
-            this.openModal(this.loginModal);
-        }
+        handleUserButtonClick(this);
     }
 
     async handleLogin() {
-        const email = document.getElementById('loginEmail').value;
-        const password = document.getElementById('loginPassword').value;
-
-        if (!email || !password) {
-            this.showToast('Please enter valid credentials');
-            return;
-        }
-
-        try {
-            await this.auth.signInWithEmailAndPassword(email, password);
-            this.showToast('Signed in successfully!');
-            this.closeModal(this.loginModal);
-            document.getElementById('loginEmail').value = '';
-            document.getElementById('loginPassword').value = '';
-        } catch (error) {
-            console.error('Login error:', error);
-            if (error.code === 'auth/user-not-found') {
-                if (confirm('No account found with this email. Sign up instead?')) {
-                    this.closeModal(this.loginModal);
-                    this.openModal(this.signupModal);
-                    document.getElementById('signupEmail').value = email;
-                }
-            } else if (error.code === 'auth/wrong-password') {
-                this.showToast('Incorrect password');
-            } else {
-                this.showToast(`Login failed: ${error.message}`);
-            }
-        }
+        await handleLogin(this);
     }
 
     async handleSignup() {
-        const email = document.getElementById('signupEmail').value;
-        const password = document.getElementById('signupPassword').value;
-
-        if (!email || !password) {
-            this.showToast('Please fill in all fields');
-            return;
-        }
-
-        if (password.length < 6) {
-            this.showToast('Password must be at least 6 characters');
-            return;
-        }
-
-        try {
-            const userCredential = await this.auth.createUserWithEmailAndPassword(email, password);
-            const user = userCredential.user;
-
-            await this.database.ref(`users/${user.uid}/settings`).set({
-                fontSize: this.state.fontSize,
-                showVerseNumbers: this.state.showVerseNumbers,
-                showHeadings: this.state.showHeadings,
-                showFootnotes: this.state.showFootnotes,
-                showCrossReferences: this.state.showCrossReferences,
-                verseByVerse: this.state.verseByVerse,
-                colorTheme: this.state.colorTheme,
-                lightMode: this.state.lightMode,
-                translation: this.state.translation || 'ESV',
-            });
-
-            this.showToast('Account created successfully!');
-            this.closeModal(this.signupModal);
-        } catch (error) {
-            console.error('Signup error:', error);
-            if (error.code === 'auth/email-already-in-use') {
-                this.showToast('An account with this email already exists');
-            } else {
-                this.showToast(`Signup failed: ${error.message}`);
-            }
-        }
+        await handleSignup(this);
     }
 
     async handleLogout() {
-        try {
-            await this.auth.signOut();
-            this.showToast('Signed out successfully');
-            this.closeModal(this.userMenuModal);
-        } catch (error) {
-            console.error('Logout error:', error);
-            this.showToast('Failed to sign out');
-        }
+        await handleLogout(this);
     }
 
     async loadUserData() {
-        if (!this.currentUser) return;
-        const data = await loadUserDataFromFirebase(this.currentUser.uid);
-        if (!data) return;
-        const s = data.settings;
-        this.state.fontSize             = s.fontSize;
-        this.state.showVerseNumbers     = s.showVerseNumbers;
-        this.state.showHeadings         = s.showHeadings;
-        this.state.showFootnotes        = s.showFootnotes;
-        this.state.showCrossReferences  = s.showCrossReferences;
-        this.state.verseByVerse         = s.verseByVerse;
-        this.state.colorTheme           = s.colorTheme;
-        this.state.lightMode            = s.lightMode;
-        this.state.translation          = normalizeTranslation(s.translation || 'ESV');
+        await loadUserData(this, normalizeTranslation);
     }
 }
 

--- a/app.js
+++ b/app.js
@@ -60,6 +60,18 @@ import {
     handleLogout,
     loadUserData,
 } from './auth.js';
+import {
+    openModal,
+    closeModal,
+    openBookModal,
+    populateBookModal,
+    openChapterModal,
+    populateChapterModal,
+    openVerseModal,
+    populateVerseModal,
+    getCurrentVerseCount,
+    attachDragToResize,
+} from './modals.js';
 
 function readBool(key, defaultValue) {
     try {
@@ -183,21 +195,10 @@ class BibleApp {
     // Bible Structure (delegated)
     // ================================
 
-    getAllBooks() {
-        return getAllBooks(this);
-    }
-
-    getChapterCount(book) {
-        return getChapterCount(this, book);
-    }
-
-    getTestament(book) {
-        return getTestament(this, book);
-    }
-
-    getDisplayName(book) {
-        return getDisplayName(this, book);
-    }
+    getAllBooks() { return getAllBooks(this); }
+    getChapterCount(book) { return getChapterCount(this, book); }
+    getTestament(book) { return getTestament(this, book); }
+    getDisplayName(book) { return getDisplayName(this, book); }
 
     // ================================
     // Initialization
@@ -274,7 +275,6 @@ class BibleApp {
 
     initializeAccordion() {
         const accordionHeaders = document.querySelectorAll('.accordion-header');
-
         accordionHeaders.forEach((header) => {
             header.addEventListener('click', () => {
                 const section = header.closest('.accordion-section');
@@ -340,143 +340,10 @@ class BibleApp {
         this.closeHelpModal?.addEventListener('click', () => this.closeModal(this.helpModal));
         this.closeSettingsModal?.addEventListener('click', () => this.closeModal(this.settingsModal));
         if (this.closeReferencesModal) {
-            this.closeReferencesModal?.addEventListener('click', () => this.closeModal(this.referencesModal));
+            this.closeReferencesModal.addEventListener('click', () => this.closeModal(this.referencesModal));
         }
 
-        // References modal drag-to-resize
-        if (this.referencesModal) {
-            const referencesContent = this.referencesModal.querySelector('.modal-content');
-            const referencesHeader = this.referencesModal.querySelector('.modal-header');
-            const referencesBody = this.referencesModal.querySelector('.modal-body');
-
-            let isRefDragging = false;
-            let refStartY = 0;
-            let refStartHeight = 0;
-            let refStartScrollTop = 0;
-
-            referencesHeader?.addEventListener('touchstart', (e) => {
-                isRefDragging = true;
-                refStartY = e.touches[0].clientY;
-                refStartHeight = referencesContent.offsetHeight;
-                refStartScrollTop = referencesBody?.scrollTop ?? 0;
-                referencesContent.classList.add('dragging');
-            }, { passive: false });
-
-            document.addEventListener('touchmove', (e) => {
-                if (!isRefDragging) return;
-                const deltaY = refStartY - e.touches[0].clientY;
-                let newH = Math.max(200, Math.min(window.innerHeight * 0.9, refStartHeight + deltaY));
-                referencesContent.style.height = `${newH}px`;
-                e.preventDefault();
-            }, { passive: false });
-
-            document.addEventListener('touchend', (e) => {
-                if (!isRefDragging) return;
-                isRefDragging = false;
-                referencesContent.classList.remove('dragging');
-                const totalDrag = e.changedTouches[0].clientY - refStartY;
-                if (totalDrag > 150 && refStartScrollTop === 0) {
-                    this.closeModal(this.referencesModal);
-                    setTimeout(() => { referencesContent.style.height = '50vh'; }, 300);
-                }
-            }, { passive: true });
-
-            let isRefMouseDragging = false;
-            let refMouseStartY = 0;
-            let refMouseStartHeight = 0;
-
-            referencesHeader?.addEventListener('mousedown', (e) => {
-                if (e.target.closest('.close-btn')) return;
-                isRefMouseDragging = true;
-                refMouseStartY = e.clientY;
-                refMouseStartHeight = referencesContent.offsetHeight;
-                referencesContent.classList.add('dragging');
-                e.preventDefault();
-            });
-
-            document.addEventListener('mousemove', (e) => {
-                if (!isRefMouseDragging) return;
-                const newH = Math.max(200, Math.min(window.innerHeight * 0.9, refMouseStartHeight + (refMouseStartY - e.clientY)));
-                referencesContent.style.height = `${newH}px`;
-            });
-
-            document.addEventListener('mouseup', (e) => {
-                if (!isRefMouseDragging) return;
-                isRefMouseDragging = false;
-                referencesContent.classList.remove('dragging');
-                if (e.clientY - refMouseStartY > 150) {
-                    this.closeModal(this.referencesModal);
-                    setTimeout(() => { referencesContent.style.height = '50vh'; }, 300);
-                }
-            });
-        }
-
-        // Settings modal drag-to-resize
-        const settingsContent = this.settingsModal.querySelector('.modal-content');
-        const settingsHeader = this.settingsModal.querySelector('.modal-header');
-        const settingsBody = this.settingsModal.querySelector('.modal-body');
-
-        let isDragging = false;
-        let startY = 0;
-        let startHeight = 0;
-        let startScrollTop = 0;
-
-        settingsHeader.addEventListener('touchstart', (e) => {
-            if (!settingsHeader.contains(e.target)) return;
-            isDragging = true;
-            startY = e.touches[0].clientY;
-            startHeight = settingsContent.offsetHeight;
-            startScrollTop = settingsBody.scrollTop;
-            settingsContent.classList.add('dragging');
-        }, { passive: false });
-
-        document.addEventListener('touchmove', (e) => {
-            if (!isDragging) return;
-            const deltaY = startY - e.touches[0].clientY;
-            const newH = Math.max(200, Math.min(window.innerHeight * 0.9, startHeight + deltaY));
-            settingsContent.style.height = `${newH}px`;
-            e.preventDefault();
-        }, { passive: false });
-
-        document.addEventListener('touchend', (e) => {
-            if (!isDragging) return;
-            isDragging = false;
-            settingsContent.classList.remove('dragging');
-            const totalDrag = e.changedTouches[0].clientY - startY;
-            if (totalDrag > 150 && startScrollTop === 0) {
-                this.closeModal(this.settingsModal);
-                setTimeout(() => { settingsContent.style.height = '50vh'; }, 300);
-            }
-        }, { passive: true });
-
-        let isMouseDragging = false;
-        let mouseStartY = 0;
-        let mouseStartHeight = 0;
-
-        settingsHeader.addEventListener('mousedown', (e) => {
-            if (e.target.closest('.close-btn')) return;
-            isMouseDragging = true;
-            mouseStartY = e.clientY;
-            mouseStartHeight = settingsContent.offsetHeight;
-            settingsContent.classList.add('dragging');
-            e.preventDefault();
-        });
-
-        document.addEventListener('mousemove', (e) => {
-            if (!isMouseDragging) return;
-            const newH = Math.max(200, Math.min(window.innerHeight * 0.9, mouseStartHeight + (mouseStartY - e.clientY)));
-            settingsContent.style.height = `${newH}px`;
-        });
-
-        document.addEventListener('mouseup', (e) => {
-            if (!isMouseDragging) return;
-            isMouseDragging = false;
-            settingsContent.classList.remove('dragging');
-            if (e.clientY - mouseStartY > 150) {
-                this.closeModal(this.settingsModal);
-                setTimeout(() => { settingsContent.style.height = '50vh'; }, 300);
-            }
-        });
+        attachDragToResize(this);
 
         this.verseNumbersToggle?.addEventListener('change', () => this.toggleSetting('showVerseNumbers'));
         this.headingsToggle?.addEventListener('change', () => this.toggleSetting('showHeadings'));
@@ -484,14 +351,14 @@ class BibleApp {
 
         this.crossReferencesToggle = document.getElementById('crossReferencesToggle');
         if (this.crossReferencesToggle) {
-            this.crossReferencesToggle?.addEventListener('change', () => this.toggleSetting('showCrossReferences'));
+            this.crossReferencesToggle.addEventListener('change', () => this.toggleSetting('showCrossReferences'));
         }
 
         this.verseByVerseToggle?.addEventListener('change', () => this.toggleVerseByVerse());
         this.fontSizeSlider?.addEventListener('input', (e) => this.updateFontSize(e.target.value));
 
         if (this.translationSelector) {
-            this.translationSelector?.addEventListener('change', async (e) => {
+            this.translationSelector.addEventListener('change', async (e) => {
                 await this.changeTranslation(e.target.value);
             });
         }
@@ -504,7 +371,6 @@ class BibleApp {
         if (themeSelector) {
             themeSelector.addEventListener('change', (e) => changeColorTheme(this, e.target.value));
         }
-
         if (lightModeToggle) {
             lightModeToggle.addEventListener('change', () => toggleTheme(this));
         }
@@ -552,23 +418,13 @@ class BibleApp {
     // Passage Loading
     // ==========================================
 
-    async _loadSavedPositionIfChanged() {
-        await loadSavedPositionIfChanged(this, withTimeout);
-    }
-
+    async _loadSavedPositionIfChanged() { await loadSavedPositionIfChanged(this, withTimeout); }
     /** @deprecated Use _loadSavedPositionIfChanged for the auth flow. */
-    async loadSavedReadingPosition() {
-        await loadSavedReadingPosition(this, withTimeout);
-    }
-
-    saveReadingPosition() {
-        saveReadingPosition(this);
-    }
+    async loadSavedReadingPosition() { await loadSavedReadingPosition(this, withTimeout); }
+    saveReadingPosition() { saveReadingPosition(this); }
 
     async loadPassage(book, chapter, restoreScroll = false) {
-        if (!restoreScroll) {
-            this.saveReadingPosition?.();
-        }
+        if (!restoreScroll) this.saveReadingPosition?.();
 
         this.state.currentBook = book;
         this.state.currentChapter = chapter;
@@ -631,21 +487,10 @@ class BibleApp {
     // Navigation (delegated)
     // ================================
 
-    navigateChapter(direction) {
-        navChapter(this, direction);
-    }
-
-    updateNavigationState() {
-        updateNavigationState(this);
-    }
-
-    navigateToNextVerse() {
-        navigateToNextVerse(this);
-    }
-
-    navigateToPreviousVerse() {
-        navigateToPreviousVerse(this);
-    }
+    navigateChapter(direction) { navChapter(this, direction); }
+    updateNavigationState() { updateNavigationState(this); }
+    navigateToNextVerse() { navigateToNextVerse(this); }
+    navigateToPreviousVerse() { navigateToPreviousVerse(this); }
 
     // ================================
     // Search (delegated)
@@ -671,135 +516,27 @@ class BibleApp {
     stripHTML(html) { return stripHTML(html); }
 
     // ================================
-    // Modals
+    // Modals (delegated)
     // ================================
 
-    openModal(modal) {
-        if (!modal) return;
-        modal.classList.add('active');
-        document.body.style.overflow = 'hidden';
-    }
+    openModal(modal) { openModal(this, modal); }
+    closeModal(modal) { closeModal(this, modal); }
+    openBookModal() { openBookModal(this); }
+    populateBookModal() { populateBookModal(this); }
+    openChapterModal() { openChapterModal(this); }
+    populateChapterModal() { populateChapterModal(this); }
+    openVerseModal() { openVerseModal(this); }
+    populateVerseModal() { populateVerseModal(this); }
+    getCurrentVerseCount() { return getCurrentVerseCount(this); }
 
-    closeModal(modal) {
-        if (!modal) return;
-        if (modal === this.settingsModal || modal === this.referencesModal) {
-            const content = modal.querySelector('.modal-content');
-            content.style.animation = 'slideDownToBottom 250ms ease';
-            setTimeout(() => {
-                modal.classList.remove('active');
-                document.body.style.overflow = '';
-                content.style.animation = '';
-            }, 250);
-        } else {
-            modal.classList.remove('active');
-            document.body.style.overflow = '';
-        }
-    }
-
-    openBookModal() {
-        this.populateBookModal();
-        this.openModal(this.bookModal);
-    }
-
-    populateBookModal() {
-        const createBookButton = (book) => {
-            const btn = document.createElement('button');
-            btn.className = 'book-item';
-            btn.textContent = this.bookAbbreviations[book] || book;
-            btn.addEventListener('click', () => {
-                this.state.selectedVerse = null;
-                this.loadPassage(book, 1);
-                this.closeModal(this.bookModal);
-            });
-            return btn;
-        };
-
-        this.oldTestamentBooks.innerHTML = '';
-        Object.keys(this.bibleBooks['Old Testament']).forEach((book) => {
-            this.oldTestamentBooks.appendChild(createBookButton(book));
-        });
-
-        this.newTestamentBooks.innerHTML = '';
-        Object.keys(this.bibleBooks['New Testament']).forEach((book) => {
-            this.newTestamentBooks.appendChild(createBookButton(book));
-        });
-    }
-
-    openChapterModal() {
-        this.populateChapterModal();
-        this.openModal(this.chapterModal);
-    }
-
-    populateChapterModal() {
-        this.chapterModalBook.textContent = this.getDisplayName(this.state.currentBook);
-        this.chapterGrid.innerHTML = '';
-
-        const chapterCount = this.getChapterCount(this.state.currentBook);
-
-        for (let i = 1; i <= chapterCount; i++) {
-            const btn = document.createElement('button');
-            btn.className = 'chapter-item';
-            btn.textContent = i;
-            btn.addEventListener('click', () => {
-                this.state.selectedVerse = null;
-                this.loadPassage(this.state.currentBook, i);
-                this.closeModal(this.chapterModal);
-            });
-            this.chapterGrid.appendChild(btn);
-        }
-    }
-
-    openVerseModal() {
-        this.populateVerseModal();
-        this.openModal(this.verseModal);
-    }
-
-    populateVerseModal() {
-        const book = this.state.currentBook;
-        const displayBook = book === 'Psalm'
-            ? `Psalm ${this.state.currentChapter}`
-            : `${this.getDisplayName(book)} ${this.state.currentChapter}`;
-        this.verseModalBook.textContent = displayBook;
-        this.verseGrid.innerHTML = '';
-
-        const verseCount = this.getCurrentVerseCount();
-
-        if (verseCount === 0) {
-            this.verseGrid.innerHTML = '<p style="text-align: center; padding: 20px; color: var(--text-secondary);">No verses found in current passage</p>';
-            return;
-        }
-
-        for (let i = 1; i <= verseCount; i++) {
-            const btn = document.createElement('button');
-            btn.className = 'chapter-item';
-            btn.textContent = i;
-            btn.addEventListener('click', () => {
-                this.scrollToVerse(i);
-                this.closeModal(this.verseModal);
-            });
-            this.verseGrid.appendChild(btn);
-        }
-    }
-
-    getCurrentVerseCount() {
-        return this.passageText.querySelectorAll('.verse-num').length;
-    }
-
-    scrollToVerse(verseNumber) {
-        scrollVerse(this, verseNumber);
-    }
-
-    applyVerseGlow() {
-        glowVerse(this);
-    }
+    scrollToVerse(verseNumber) { scrollVerse(this, verseNumber); }
+    applyVerseGlow() { glowVerse(this); }
 
     // ================================
     // Settings
     // ================================
 
-    checkApiKey() {
-        checkApiKey(this);
-    }
+    checkApiKey() { checkApiKey(this); }
 
     loadLocalSettings() {
         try { this.state.fontSize = parseInt(localStorage.getItem('fontSize') || '18', 10); } catch (_) { this.state.fontSize = 18; }
@@ -815,9 +552,7 @@ class BibleApp {
 
     applySettings() {
         const themeSelector = document.getElementById('themeSelector');
-        if (themeSelector && this.state.colorTheme) {
-            themeSelector.value = this.state.colorTheme;
-        }
+        if (themeSelector && this.state.colorTheme) themeSelector.value = this.state.colorTheme;
         changeColorTheme(this, this.state.colorTheme || 'dracula');
 
         if (this.translationSelector && this.state.translation) {
@@ -832,14 +567,11 @@ class BibleApp {
 
         document.body.classList.toggle('hide-verse-numbers', !this.state.showVerseNumbers);
         if (this.verseNumbersToggle) this.verseNumbersToggle.checked = !!this.state.showVerseNumbers;
-
         if (this.headingsToggle) this.headingsToggle.checked = !!this.state.showHeadings;
         if (this.footnotesToggle) this.footnotesToggle.checked = !!this.state.showFootnotes;
         if (this.crossReferencesToggle) this.crossReferencesToggle.checked = !!this.state.showCrossReferences;
 
-        if (this.passageText) {
-            this.passageText.classList.toggle('verse-by-verse', !!this.state.verseByVerse);
-        }
+        if (this.passageText) this.passageText.classList.toggle('verse-by-verse', !!this.state.verseByVerse);
         if (this.verseByVerseToggle) this.verseByVerseToggle.checked = !!this.state.verseByVerse;
 
         const fontSize = this.state.fontSize || 18;
@@ -991,79 +723,65 @@ class BibleApp {
     }
 
     // ================================
-    // Firebase Authentication
+    // Firebase Authentication (delegated)
     // ================================
 
-    handleUserButtonClick() {
-        handleUserButtonClick(this);
-    }
-
-    async handleLogin() {
-        await handleLogin(this);
-    }
-
-    async handleSignup() {
-        await handleSignup(this);
-    }
-
-    async handleLogout() {
-        await handleLogout(this);
-    }
-
-    async loadUserData() {
-        await loadUserData(this, normalizeTranslation);
-    }
+    handleUserButtonClick() { handleUserButtonClick(this); }
+    async handleLogin() { await handleLogin(this); }
+    async handleSignup() { await handleSignup(this); }
+    async handleLogout() { await handleLogout(this); }
+    async loadUserData() { await loadUserData(this, normalizeTranslation); }
 }
 
 
 /* ─── Service Worker & Update Toast ─── */
 async function registerServiceWorker(appInstance) {
-  if (!('serviceWorker' in navigator)) return;
-  try {
-    const reg = await navigator.serviceWorker.register('./sw.js', { scope: './' });
+    if (!('serviceWorker' in navigator)) return;
+    try {
+        const reg = await navigator.serviceWorker.register('./sw.js', { scope: './' });
 
-    const buildMeta = document.querySelector('meta[name="build-id"]')?.content || '__BUILD_ID__';
-    console.info('[BUILD_ID]', buildMeta);
+        const buildMeta = document.querySelector('meta[name="build-id"]')?.content || '__BUILD_ID__';
+        console.info('[BUILD_ID]', buildMeta);
 
-    navigator.serviceWorker.addEventListener('message', (e) => {
-      if (e.data?.type === 'NEW_VERSION') showUpdateToast(appInstance);
-      if (e.data?.type === 'RELOAD') window.location.reload();
-    });
+        navigator.serviceWorker.addEventListener('message', (e) => {
+            if (e.data?.type === 'NEW_VERSION') showUpdateToast(appInstance);
+            if (e.data?.type === 'RELOAD') window.location.reload();
+        });
 
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') {
-        reg.update().catch((err) => console.warn('SW update check failed', err));
-      }
-    });
-  } catch (err) {
-    console.warn('SW registration failed', err);
-  }
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible') {
+                reg.update().catch((err) => console.warn('SW update check failed', err));
+            }
+        });
+    } catch (err) {
+        console.warn('SW registration failed', err);
+    }
 }
 
 function showUpdateToast(appInstance) {
-  const toast = document.getElementById('toast');
-  if (!toast) return;
-  toast.innerHTML = '';
+    const toast = document.getElementById('toast');
+    if (!toast) return;
+    toast.innerHTML = '';
 
-  const text = document.createElement('span');
-  text.textContent = 'A new version is available.';
-  text.style.flex = '1';
+    const text = document.createElement('span');
+    text.textContent = 'A new version is available.';
+    text.style.flex = '1';
 
-  const action = document.createElement('button');
-  action.textContent = 'Refresh';
-  action.className = 'toast-action';
-  action.addEventListener('click', () => location.reload());
+    const action = document.createElement('button');
+    action.textContent = 'Refresh';
+    action.className = 'toast-action';
+    action.addEventListener('click', () => location.reload());
 
-  const dismiss = document.createElement('button');
-  dismiss.textContent = '\u00d7';
-  dismiss.className = 'toast-dismiss';
-  dismiss.addEventListener('click', () => toast.classList.remove('show'));
+    const dismiss = document.createElement('button');
+    dismiss.textContent = '\u00d7';
+    dismiss.className = 'toast-dismiss';
+    dismiss.addEventListener('click', () => toast.classList.remove('show'));
 
-  toast.appendChild(text);
-  toast.appendChild(action);
-  toast.appendChild(dismiss);
-  toast.classList.add('show');
-  setTimeout(() => toast.classList.remove('show'), 30000);
+    toast.appendChild(text);
+    toast.appendChild(action);
+    toast.appendChild(dismiss);
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 30000);
 }
 
 (async () => {

--- a/app.js
+++ b/app.js
@@ -10,12 +10,7 @@ import {
     scrollToVerse as scrollVerse,
     applyVerseGlow as glowVerse,
 } from './reading-state.js';
-import {
-    cacheElements,
-    loadTheme,
-    toggleTheme,
-    changeColorTheme,
-} from './ui.js';
+import { cacheElements, loadTheme, toggleTheme, changeColorTheme } from './ui.js';
 import {
     initializeBibleStructure,
     getAllBooks,
@@ -23,69 +18,33 @@ import {
     getTestament,
     getDisplayName,
 } from './bible-structure.js';
+import { updateNavigationState, navigateToNextVerse, navigateToPreviousVerse } from './navigation.js';
 import {
-    updateNavigationState,
-    navigateToNextVerse,
-    navigateToPreviousVerse,
-} from './navigation.js';
-import {
-    toggleSearch,
-    closeSearch,
-    handleSearch,
-    handleSearchKeydown,
-    refreshSearchResultItems,
-    setSearchSelectedIndex,
-    activateSelectedSearchResult,
-    isPassageReference,
-    handlePassageReference,
-    fetchAllSearchResults,
-    groupSearchResultsByCanon,
-    performKeywordSearch,
-    displaySearchResults,
-    parseReference,
-    loadPassageFromReference,
-    escapeRegExp,
-    highlightSearchTerm,
-    stripHTML,
+    toggleSearch, closeSearch, handleSearch, handleSearchKeydown,
+    refreshSearchResultItems, setSearchSelectedIndex, activateSelectedSearchResult,
+    isPassageReference, handlePassageReference, fetchAllSearchResults,
+    groupSearchResultsByCanon, performKeywordSearch, displaySearchResults,
+    parseReference, loadPassageFromReference, escapeRegExp, highlightSearchTerm, stripHTML,
 } from './search.js';
 import {
-    loadSavedPositionIfChanged,
-    loadSavedReadingPosition,
-    saveReadingPosition,
-    checkApiKey,
-    handleUserButtonClick,
-    handleLogin,
-    handleSignup,
-    handleLogout,
-    loadUserData,
+    loadSavedPositionIfChanged, loadSavedReadingPosition, saveReadingPosition,
+    checkApiKey, handleUserButtonClick, handleLogin, handleSignup, handleLogout, loadUserData,
 } from './auth.js';
 import {
-    openModal,
-    closeModal,
-    openBookModal,
-    populateBookModal,
-    openChapterModal,
-    populateChapterModal,
-    openVerseModal,
-    populateVerseModal,
-    getCurrentVerseCount,
-    attachDragToResize,
+    openModal, closeModal,
+    openBookModal, populateBookModal,
+    openChapterModal, populateChapterModal,
+    openVerseModal, populateVerseModal,
+    getCurrentVerseCount, attachDragToResize,
 } from './modals.js';
 import {
-    loadLocalSettings,
-    applySettings,
-    toggleSetting,
-    toggleVerseByVerse,
-    updateFontSize,
-    changeTranslation,
-    updateCopyright,
+    loadLocalSettings, applySettings, toggleSetting,
+    toggleVerseByVerse, updateFontSize, changeTranslation, updateCopyright,
 } from './settings.js';
+import { handleKeyboardShortcuts } from './keyboard.js';
 
 const TRANSLATION_ALIASES = { NRSVue: 'NRSVUE' };
-
-function normalizeTranslation(t) {
-    return TRANSLATION_ALIASES[t] || t;
-}
+function normalizeTranslation(t) { return TRANSLATION_ALIASES[t] || t; }
 
 function withTimeout(promise, ms, fallback = null) {
     return Promise.race([
@@ -161,17 +120,12 @@ class BibleApp {
                 const delta = y - this.chromeScrollLastY;
                 const modalOpen  = !!document.querySelector('.modal.active');
                 const searchOpen = !!this.searchContainer?.classList.contains('active');
-
                 if (y <= 0 || modalOpen || searchOpen) {
                     this.showChrome();
-                    this.chromeScrollLastY = y;
-                    this.chromeScrollTicking = false;
-                    return;
+                } else {
+                    if (delta > this.chromeDelta)  this.hideChrome();
+                    if (delta < -this.chromeDelta) this.showChrome();
                 }
-
-                if (delta > this.chromeDelta)  this.hideChrome();
-                if (delta < -this.chromeDelta) this.showChrome();
-
                 this.chromeScrollLastY = y;
                 this.chromeScrollTicking = false;
             });
@@ -204,17 +158,14 @@ class BibleApp {
         cacheElements(this);
         loadTheme(this);
 
-        const themeSelector  = document.getElementById('themeSelector');
+        const themeSelector   = document.getElementById('themeSelector');
         const lightModeToggle = document.getElementById('lightModeToggle');
-
         if (themeSelector) {
             let saved = 'dracula';
             try { saved = localStorage.getItem('colorTheme') || 'dracula'; } catch (_) {}
             themeSelector.value = saved;
         }
-        if (lightModeToggle) {
-            lightModeToggle.checked = document.body.classList.contains('light-mode');
-        }
+        if (lightModeToggle) lightModeToggle.checked = document.body.classList.contains('light-mode');
 
         this.attachEventListeners();
         this.initializeAccordion();
@@ -256,16 +207,13 @@ class BibleApp {
             }
         }
         this._copyrightMap = {};
-        for (const t of translations) {
-            this._copyrightMap[t.id] = t.copyright || '';
-        }
+        for (const t of translations) this._copyrightMap[t.id] = t.copyright || '';
     }
 
     initializeAccordion() {
         document.querySelectorAll('.accordion-header').forEach((header) => {
             header.addEventListener('click', () => header.closest('.accordion-section').classList.toggle('active'));
         });
-
         const openAccountBtn = document.getElementById('openAccountBtn');
         if (openAccountBtn) {
             openAccountBtn.addEventListener('click', () => {
@@ -277,19 +225,19 @@ class BibleApp {
 
     attachEventListeners() {
         this.searchToggleBtn?.addEventListener('click', () => this.toggleSearch());
-        this.helpBtn?.addEventListener('click', () => this.openModal(this.helpModal));
+        this.helpBtn?.addEventListener('click',     () => this.openModal(this.helpModal));
         this.settingsBtn?.addEventListener('click', () => this.openModal(this.settingsModal));
 
         this.closeSearchBtn?.addEventListener('click', () => this.closeSearch());
-        this.searchInput?.addEventListener('input', (e) => this.handleSearch(e.target.value));
+        this.searchInput?.addEventListener('input',   (e) => this.handleSearch(e.target.value));
         this.searchInput?.addEventListener('keydown', (e) => this.handleSearchKeydown(e));
 
         this.prevChapterBtn?.addEventListener('click', () => this.navigateChapter(-1));
         this.nextChapterBtn?.addEventListener('click', () => this.navigateChapter(1));
-        this.bookSelector?.addEventListener('click', () => this.openBookModal());
-        this.chapterSelector?.addEventListener('click', () => this.openChapterModal());
-        this.verseSelector?.addEventListener('click', () => this.openVerseModal());
-        this.closeVerseModal?.addEventListener('click', () => this.closeModal(this.verseModal));
+        this.bookSelector?.addEventListener('click',   () => this.openBookModal());
+        this.chapterSelector?.addEventListener('click',() => this.openChapterModal());
+        this.verseSelector?.addEventListener('click',  () => this.openVerseModal());
+        this.closeVerseModal?.addEventListener('click',() => this.closeModal(this.verseModal));
 
         this.referencesModal        = document.getElementById('referencesModal');
         this.closeReferencesModal   = document.getElementById('closeReferencesModal');
@@ -307,10 +255,10 @@ class BibleApp {
             modal.addEventListener('click', (e) => { if (e.target === modal) this.closeModal(modal); });
         });
 
-        this.closeBookModal?.addEventListener('click',     () => this.closeModal(this.bookModal));
-        this.closeChapterModal?.addEventListener('click',  () => this.closeModal(this.chapterModal));
-        this.closeHelpModal?.addEventListener('click',     () => this.closeModal(this.helpModal));
-        this.closeSettingsModal?.addEventListener('click', () => this.closeModal(this.settingsModal));
+        this.closeBookModal?.addEventListener('click',       () => this.closeModal(this.bookModal));
+        this.closeChapterModal?.addEventListener('click',    () => this.closeModal(this.chapterModal));
+        this.closeHelpModal?.addEventListener('click',       () => this.closeModal(this.helpModal));
+        this.closeSettingsModal?.addEventListener('click',   () => this.closeModal(this.settingsModal));
         this.closeReferencesModal?.addEventListener('click', () => this.closeModal(this.referencesModal));
 
         attachDragToResize(this);
@@ -323,11 +271,11 @@ class BibleApp {
         this.crossReferencesToggle?.addEventListener('change', () => this.toggleSetting('showCrossReferences'));
 
         this.verseByVerseToggle?.addEventListener('change', () => this.toggleVerseByVerse());
-        this.fontSizeSlider?.addEventListener('input', (e) => this.updateFontSize(e.target.value));
+        this.fontSizeSlider?.addEventListener('input',  (e) => this.updateFontSize(e.target.value));
         this.translationSelector?.addEventListener('change', async (e) => this.changeTranslation(e.target.value));
 
         this.themeToggleBtn?.addEventListener('click', () => toggleTheme(this));
-        document.getElementById('themeSelector')?.addEventListener('change', (e) => changeColorTheme(this, e.target.value));
+        document.getElementById('themeSelector')?.addEventListener('change',   (e) => changeColorTheme(this, e.target.value));
         document.getElementById('lightModeToggle')?.addEventListener('change', () => toggleTheme(this));
 
         this.userBtn?.addEventListener('click', () => this.handleUserButtonClick());
@@ -342,7 +290,7 @@ class BibleApp {
             this.closeModal(this.signupModal);
             this.openModal(this.loginModal);
         });
-        document.getElementById('loginForm')?.addEventListener('submit', (e) => { e.preventDefault(); this.handleLogin(); });
+        document.getElementById('loginForm')?.addEventListener('submit',  (e) => { e.preventDefault(); this.handleLogin(); });
         document.getElementById('signupForm')?.addEventListener('submit', (e) => { e.preventDefault(); this.handleSignup(); });
         document.getElementById('logoutBtn')?.addEventListener('click', () => this.handleLogout());
 
@@ -400,8 +348,8 @@ class BibleApp {
         this.passageTitle.textContent = book === 'Psalm'
             ? `Psalm ${chapter}`
             : `${this.getDisplayName(book)} ${chapter}`;
-        this.passageText.innerHTML  = data.passages[0];
-        this.originalPassageHtml    = this.passageText.innerHTML;
+        this.passageText.innerHTML = data.passages[0];
+        this.originalPassageHtml   = this.passageText.innerHTML;
         this.passageText.classList.toggle('verse-by-verse', !!this.state.verseByVerse);
 
         this.updateCopyright();
@@ -409,7 +357,6 @@ class BibleApp {
         this.chromeSuspend = true;
         document.body.classList.add('chrome-no-transition');
         this.showChrome();
-
         window.scrollTo(0, restoreScroll ? (this.lastScrollPosition || 0) : 0);
 
         requestAnimationFrame(() => {
@@ -425,10 +372,10 @@ class BibleApp {
     // Navigation (delegated)
     // ================================
 
-    navigateChapter(direction)  { navChapter(this, direction); }
-    updateNavigationState()     { updateNavigationState(this); }
-    navigateToNextVerse()       { navigateToNextVerse(this); }
-    navigateToPreviousVerse()   { navigateToPreviousVerse(this); }
+    navigateChapter(direction) { navChapter(this, direction); }
+    updateNavigationState()    { updateNavigationState(this); }
+    navigateToNextVerse()      { navigateToNextVerse(this); }
+    navigateToPreviousVerse()  { navigateToPreviousVerse(this); }
 
     // ================================
     // Search (delegated)
@@ -457,29 +404,35 @@ class BibleApp {
     // Modals (delegated)
     // ================================
 
-    openModal(modal)          { openModal(this, modal); }
-    closeModal(modal)         { closeModal(this, modal); }
-    openBookModal()           { openBookModal(this); }
-    populateBookModal()       { populateBookModal(this); }
-    openChapterModal()        { openChapterModal(this); }
-    populateChapterModal()    { populateChapterModal(this); }
-    openVerseModal()          { openVerseModal(this); }
-    populateVerseModal()      { populateVerseModal(this); }
-    getCurrentVerseCount()    { return getCurrentVerseCount(this); }
-    scrollToVerse(n)          { scrollVerse(this, n); }
-    applyVerseGlow()          { glowVerse(this); }
+    openModal(modal)       { openModal(this, modal); }
+    closeModal(modal)      { closeModal(this, modal); }
+    openBookModal()        { openBookModal(this); }
+    populateBookModal()    { populateBookModal(this); }
+    openChapterModal()     { openChapterModal(this); }
+    populateChapterModal() { populateChapterModal(this); }
+    openVerseModal()       { openVerseModal(this); }
+    populateVerseModal()   { populateVerseModal(this); }
+    getCurrentVerseCount() { return getCurrentVerseCount(this); }
+    scrollToVerse(n)       { scrollVerse(this, n); }
+    applyVerseGlow()       { glowVerse(this); }
 
     // ================================
     // Settings (delegated)
     // ================================
 
-    loadLocalSettings()                    { loadLocalSettings(this); }
-    applySettings()                        { applySettings(this); }
-    async toggleSetting(s)                 { await toggleSetting(this, s); }
-    async toggleVerseByVerse()             { await toggleVerseByVerse(this); }
-    async updateFontSize(size)             { await updateFontSize(this, size); }
-    async changeTranslation(t)             { await changeTranslation(this, t); }
-    updateCopyright()                      { updateCopyright(this); }
+    loadLocalSettings()          { loadLocalSettings(this); }
+    applySettings()              { applySettings(this); }
+    async toggleSetting(s)       { await toggleSetting(this, s); }
+    async toggleVerseByVerse()   { await toggleVerseByVerse(this); }
+    async updateFontSize(size)   { await updateFontSize(this, size); }
+    async changeTranslation(t)   { await changeTranslation(this, t); }
+    updateCopyright()            { updateCopyright(this); }
+
+    // ================================
+    // Keyboard (delegated)
+    // ================================
+
+    handleKeyboardShortcuts(e)   { handleKeyboardShortcuts(this, e); }
 
     // ================================
     // Utilities
@@ -495,9 +448,7 @@ class BibleApp {
             .catch((err) => { console.error('Failed to copy:', err); this.showToast('Failed to copy passage'); });
     }
 
-    showError(message) {
-        this.passageText.innerHTML = `<div class="error">${message}</div>`;
-    }
+    showError(message) { this.passageText.innerHTML = `<div class="error">${message}</div>`; }
 
     showToast(message) {
         if (!this.toast) return;
@@ -506,48 +457,15 @@ class BibleApp {
         setTimeout(() => this.toast.classList.remove('show'), 3000);
     }
 
-    handleKeyboardShortcuts(e) {
-        if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
-            e.preventDefault();
-            this.toggleSearch();
-        }
-
-        if (e.key === 'Escape') {
-            const modals = [
-                this.bookModal, this.chapterModal, this.helpModal,
-                this.settingsModal, this.loginModal, this.signupModal,
-                this.userMenuModal, this.verseModal, this.referencesModal,
-            ];
-            modals.forEach((m) => { if (m?.classList.contains('active')) this.closeModal(m); });
-            if (this.searchContainer?.classList.contains('active')) this.closeSearch();
-        }
-
-        if (!document.querySelector('.modal.active') && !this.searchContainer?.classList.contains('active')) {
-            if      (e.key === 'ArrowLeft'  || e.key === 'h') { e.preventDefault(); this.navigateChapter(-1); }
-            else if (e.key === 'ArrowRight' || e.key === 'l') { e.preventDefault(); this.navigateChapter(1); }
-            else if (e.key === 'ArrowUp'    || e.key === 'k') { e.preventDefault(); this.navigateToPreviousVerse(); }
-            else if (e.key === 'ArrowDown'  || e.key === 'j') { e.preventDefault(); this.navigateToNextVerse(); }
-            else if (e.key === 'v') {
-                e.preventDefault();
-                this.verseByVerseToggle.checked = !this.verseByVerseToggle.checked;
-                this.toggleVerseByVerse();
-            } else if (e.key === 's' && this.headingsToggle) {
-                e.preventDefault();
-                this.headingsToggle.checked = !this.headingsToggle.checked;
-                this.toggleSetting('showHeadings');
-            }
-        }
-    }
-
     // ================================
     // Firebase Auth (delegated)
     // ================================
 
-    handleUserButtonClick()  { handleUserButtonClick(this); }
-    async handleLogin()      { await handleLogin(this); }
-    async handleSignup()     { await handleSignup(this); }
-    async handleLogout()     { await handleLogout(this); }
-    async loadUserData()     { await loadUserData(this, normalizeTranslation); }
+    handleUserButtonClick() { handleUserButtonClick(this); }
+    async handleLogin()     { await handleLogin(this); }
+    async handleSignup()    { await handleSignup(this); }
+    async handleLogout()    { await handleLogout(this); }
+    async loadUserData()    { await loadUserData(this, normalizeTranslation); }
 }
 
 
@@ -557,14 +475,11 @@ async function registerServiceWorker(appInstance) {
     if (!('serviceWorker' in navigator)) return;
     try {
         const reg = await navigator.serviceWorker.register('./sw.js', { scope: './' });
-        const buildMeta = document.querySelector('meta[name="build-id"]')?.content || '__BUILD_ID__';
-        console.info('[BUILD_ID]', buildMeta);
-
+        console.info('[BUILD_ID]', document.querySelector('meta[name="build-id"]')?.content || '__BUILD_ID__');
         navigator.serviceWorker.addEventListener('message', (e) => {
             if (e.data?.type === 'NEW_VERSION') showUpdateToast(appInstance);
             if (e.data?.type === 'RELOAD') window.location.reload();
         });
-
         document.addEventListener('visibilitychange', () => {
             if (document.visibilityState === 'visible')
                 reg.update().catch((err) => console.warn('SW update check failed', err));
@@ -578,16 +493,12 @@ function showUpdateToast(appInstance) {
     const toast = document.getElementById('toast');
     if (!toast) return;
     toast.innerHTML = '';
-
-    const text = Object.assign(document.createElement('span'), { textContent: 'A new version is available.' });
+    const text    = Object.assign(document.createElement('span'),  { textContent: 'A new version is available.' });
+    const action  = Object.assign(document.createElement('button'),{ textContent: 'Refresh',  className: 'toast-action' });
+    const dismiss = Object.assign(document.createElement('button'),{ textContent: '\u00d7', className: 'toast-dismiss' });
     text.style.flex = '1';
-
-    const action = Object.assign(document.createElement('button'), { textContent: 'Refresh', className: 'toast-action' });
-    action.addEventListener('click', () => location.reload());
-
-    const dismiss = Object.assign(document.createElement('button'), { textContent: '\u00d7', className: 'toast-dismiss' });
+    action.addEventListener('click',  () => location.reload());
     dismiss.addEventListener('click', () => toast.classList.remove('show'));
-
     toast.append(text, action, dismiss);
     toast.classList.add('show');
     setTimeout(() => toast.classList.remove('show'), 30000);

--- a/app.js
+++ b/app.js
@@ -25,6 +25,11 @@ import {
     getTestament,
     getDisplayName,
 } from './bible-structure.js';
+import {
+    updateNavigationState,
+    navigateToNextVerse,
+    navigateToPreviousVerse,
+} from './navigation.js';
 
 function readBool(key, defaultValue) {
     try {
@@ -662,7 +667,7 @@ class BibleApp {
     }
 
     // ================================
-    // Navigation
+    // Navigation (delegated)
     // ================================
 
     navigateChapter(direction) {
@@ -670,18 +675,15 @@ class BibleApp {
     }
 
     updateNavigationState() {
-        const book = this.state.currentBook;
-        const abbr = this.bookAbbreviations[book] || book;
-        this.currentBookSpan.textContent = abbr;
-        this.currentChapterSpan.textContent = this.state.currentChapter;
+        updateNavigationState(this);
+    }
 
-        const books = this.getAllBooks();
-        const currentBookIndex = books.indexOf(book);
-        const isFirstChapter = this.state.currentChapter === 1;
-        const isLastChapter = this.state.currentChapter === this.getChapterCount(book);
+    navigateToNextVerse() {
+        navigateToNextVerse(this);
+    }
 
-        if (this.prevChapterBtn) this.prevChapterBtn.disabled = currentBookIndex === 0 && isFirstChapter;
-        if (this.nextChapterBtn) this.nextChapterBtn.disabled = currentBookIndex === books.length - 1 && isLastChapter;
+    navigateToPreviousVerse() {
+        navigateToPreviousVerse(this);
     }
 
     // ================================
@@ -1184,42 +1186,6 @@ class BibleApp {
 
     scrollToVerse(verseNumber) {
         scrollVerse(this, verseNumber);
-    }
-
-    navigateToNextVerse() {
-        const currentVerse = this.state.selectedVerse || 1;
-        const maxVerse = this.getCurrentVerseCount();
-
-        if (currentVerse < maxVerse) {
-            this.scrollToVerse(currentVerse + 1);
-        } else {
-            this.navigateChapter(1);
-        }
-    }
-
-    navigateToPreviousVerse() {
-        const currentVerse = this.state.selectedVerse || 1;
-
-        if (currentVerse > 1) {
-            this.scrollToVerse(currentVerse - 1);
-        } else {
-            const books = this.getAllBooks();
-            const currentBookIndex = books.indexOf(this.state.currentBook);
-            const isFirstChapter = this.state.currentChapter === 1;
-
-            if (currentBookIndex === 0 && isFirstChapter) return;
-
-            let newChapter = this.state.currentChapter - 1;
-            let newBook = this.state.currentBook;
-
-            if (newChapter < 1) {
-                newBook = books[currentBookIndex - 1];
-                newChapter = this.getChapterCount(newBook);
-            }
-
-            this.state.selectedVerse = null;
-            this.loadPassage(newBook, newChapter);
-        }
     }
 
     applyVerseGlow() {

--- a/app.js
+++ b/app.js
@@ -14,7 +14,6 @@ import {
     cacheElements,
     loadTheme,
     toggleTheme,
-    updateThemeIcon,
     changeColorTheme,
 } from './ui.js';
 import {
@@ -72,20 +71,17 @@ import {
     getCurrentVerseCount,
     attachDragToResize,
 } from './modals.js';
+import {
+    loadLocalSettings,
+    applySettings,
+    toggleSetting,
+    toggleVerseByVerse,
+    updateFontSize,
+    changeTranslation,
+    updateCopyright,
+} from './settings.js';
 
-function readBool(key, defaultValue) {
-    try {
-        const v = localStorage.getItem(key);
-        if (v === null) return defaultValue;
-        if (v === 'true') return true;
-        if (v === 'false') return false;
-        return defaultValue;
-    } catch { return defaultValue; }
-}
-
-const TRANSLATION_ALIASES = {
-    NRSVue: 'NRSVUE',
-};
+const TRANSLATION_ALIASES = { NRSVue: 'NRSVUE' };
 
 function normalizeTranslation(t) {
     return TRANSLATION_ALIASES[t] || t;
@@ -100,11 +96,11 @@ function withTimeout(promise, ms, fallback = null) {
 
 class BibleApp {
     constructor() {
-        this.auth = window.firebaseAuth;
+        this.auth     = window.firebaseAuth;
         this.database = window.firebaseDatabase;
         this.currentUser = null;
-
         this._copyrightMap = {};
+        this._normalizeTranslation = normalizeTranslation;
 
         this.bibleBooks = initializeBibleStructure();
 
@@ -124,9 +120,7 @@ class BibleApp {
             '1 John': '1John', '2 John': '2John', '3 John': '3John', Jude: 'Jude', Revelation: 'Rev',
         };
 
-        this.bookDisplayNames = {
-            Psalm: 'Psalms',
-        };
+        this.bookDisplayNames = { Psalm: 'Psalms' };
 
         this.state = initializeState();
         this.searchTimeout = null;
@@ -162,11 +156,10 @@ class BibleApp {
                 this.chromeScrollTicking = false;
                 return;
             }
-
             window.requestAnimationFrame(() => {
                 const y = window.scrollY || window.pageYOffset || 0;
                 const delta = y - this.chromeScrollLastY;
-                const modalOpen = !!document.querySelector('.modal.active');
+                const modalOpen  = !!document.querySelector('.modal.active');
                 const searchOpen = !!this.searchContainer?.classList.contains('active');
 
                 if (y <= 0 || modalOpen || searchOpen) {
@@ -176,7 +169,7 @@ class BibleApp {
                     return;
                 }
 
-                if (delta > this.chromeDelta) this.hideChrome();
+                if (delta > this.chromeDelta)  this.hideChrome();
                 if (delta < -this.chromeDelta) this.showChrome();
 
                 this.chromeScrollLastY = y;
@@ -195,10 +188,10 @@ class BibleApp {
     // Bible Structure (delegated)
     // ================================
 
-    getAllBooks() { return getAllBooks(this); }
+    getAllBooks()          { return getAllBooks(this); }
     getChapterCount(book) { return getChapterCount(this, book); }
-    getTestament(book) { return getTestament(this, book); }
-    getDisplayName(book) { return getDisplayName(this, book); }
+    getTestament(book)    { return getTestament(this, book); }
+    getDisplayName(book)  { return getDisplayName(this, book); }
 
     // ================================
     // Initialization
@@ -206,20 +199,19 @@ class BibleApp {
 
     async init() {
         await this._loadTranslationRegistry();
-        try { await registerServiceWorker(this); } catch (_swErr) { console.warn('Service worker unavailable:', _swErr); }
+        try { await registerServiceWorker(this); } catch (_) { console.warn('Service worker unavailable:', _); }
 
         cacheElements(this);
         loadTheme(this);
 
-        const themeSelector = document.getElementById('themeSelector');
+        const themeSelector  = document.getElementById('themeSelector');
         const lightModeToggle = document.getElementById('lightModeToggle');
 
         if (themeSelector) {
-            let savedTheme = 'dracula';
-            try { savedTheme = localStorage.getItem('colorTheme') || 'dracula'; } catch (_) {}
-            themeSelector.value = savedTheme;
+            let saved = 'dracula';
+            try { saved = localStorage.getItem('colorTheme') || 'dracula'; } catch (_) {}
+            themeSelector.value = saved;
         }
-
         if (lightModeToggle) {
             lightModeToggle.checked = document.body.classList.contains('light-mode');
         }
@@ -234,9 +226,7 @@ class BibleApp {
 
         if (!this.auth || !this.database) {
             console.error('Firebase auth/database not ready when app initialized.');
-            setTimeout(() => {
-                this.showToast('Sign in is temporarily unavailable. Please refresh the page.');
-            }, 500);
+            setTimeout(() => this.showToast('Sign in is temporarily unavailable. Please refresh the page.'), 500);
             return;
         }
 
@@ -255,7 +245,6 @@ class BibleApp {
 
     async _loadTranslationRegistry() {
         const translations = await loadTranslationIndex();
-
         const select = document.getElementById('translationSelector');
         if (select && translations.length > 0) {
             select.innerHTML = '';
@@ -266,7 +255,6 @@ class BibleApp {
                 select.appendChild(opt);
             }
         }
-
         this._copyrightMap = {};
         for (const t of translations) {
             this._copyrightMap[t.id] = t.copyright || '';
@@ -274,23 +262,15 @@ class BibleApp {
     }
 
     initializeAccordion() {
-        const accordionHeaders = document.querySelectorAll('.accordion-header');
-        accordionHeaders.forEach((header) => {
-            header.addEventListener('click', () => {
-                const section = header.closest('.accordion-section');
-                section.classList.toggle('active');
-            });
+        document.querySelectorAll('.accordion-header').forEach((header) => {
+            header.addEventListener('click', () => header.closest('.accordion-section').classList.toggle('active'));
         });
 
         const openAccountBtn = document.getElementById('openAccountBtn');
         if (openAccountBtn) {
             openAccountBtn.addEventListener('click', () => {
                 this.closeModal(this.settingsModal);
-                if (this.currentUser) {
-                    this.openModal(this.userMenuModal);
-                } else {
-                    this.openModal(this.loginModal);
-                }
+                this.openModal(this.currentUser ? this.userMenuModal : this.loginModal);
             });
         }
     }
@@ -311,69 +291,44 @@ class BibleApp {
         this.verseSelector?.addEventListener('click', () => this.openVerseModal());
         this.closeVerseModal?.addEventListener('click', () => this.closeModal(this.verseModal));
 
-        this.referencesModal = document.getElementById('referencesModal');
-        this.closeReferencesModal = document.getElementById('closeReferencesModal');
-        this.footnotesSection = document.getElementById('footnotesSection');
-        this.footnotesContent = document.getElementById('footnotesContent');
+        this.referencesModal        = document.getElementById('referencesModal');
+        this.closeReferencesModal   = document.getElementById('closeReferencesModal');
+        this.footnotesSection       = document.getElementById('footnotesSection');
+        this.footnotesContent       = document.getElementById('footnotesContent');
         this.crossReferencesSection = document.getElementById('crossReferencesSection');
         this.crossReferencesContent = document.getElementById('crossReferencesContent');
 
         [
-            this.bookModal,
-            this.chapterModal,
-            this.verseModal,
-            this.settingsModal,
-            this.helpModal,
-            this.loginModal,
-            this.signupModal,
-            this.userMenuModal,
-            this.referencesModal,
+            this.bookModal, this.chapterModal, this.verseModal,
+            this.settingsModal, this.helpModal, this.loginModal,
+            this.signupModal, this.userMenuModal, this.referencesModal,
         ].forEach((modal) => {
             if (!modal) return;
-            modal.addEventListener('click', (e) => {
-                if (e.target === modal) this.closeModal(modal);
-            });
+            modal.addEventListener('click', (e) => { if (e.target === modal) this.closeModal(modal); });
         });
 
-        this.closeBookModal?.addEventListener('click', () => this.closeModal(this.bookModal));
-        this.closeChapterModal?.addEventListener('click', () => this.closeModal(this.chapterModal));
-        this.closeHelpModal?.addEventListener('click', () => this.closeModal(this.helpModal));
+        this.closeBookModal?.addEventListener('click',     () => this.closeModal(this.bookModal));
+        this.closeChapterModal?.addEventListener('click',  () => this.closeModal(this.chapterModal));
+        this.closeHelpModal?.addEventListener('click',     () => this.closeModal(this.helpModal));
         this.closeSettingsModal?.addEventListener('click', () => this.closeModal(this.settingsModal));
-        if (this.closeReferencesModal) {
-            this.closeReferencesModal.addEventListener('click', () => this.closeModal(this.referencesModal));
-        }
+        this.closeReferencesModal?.addEventListener('click', () => this.closeModal(this.referencesModal));
 
         attachDragToResize(this);
 
         this.verseNumbersToggle?.addEventListener('change', () => this.toggleSetting('showVerseNumbers'));
-        this.headingsToggle?.addEventListener('change', () => this.toggleSetting('showHeadings'));
-        this.footnotesToggle?.addEventListener('change', () => this.toggleSetting('showFootnotes'));
+        this.headingsToggle?.addEventListener('change',     () => this.toggleSetting('showHeadings'));
+        this.footnotesToggle?.addEventListener('change',    () => this.toggleSetting('showFootnotes'));
 
         this.crossReferencesToggle = document.getElementById('crossReferencesToggle');
-        if (this.crossReferencesToggle) {
-            this.crossReferencesToggle.addEventListener('change', () => this.toggleSetting('showCrossReferences'));
-        }
+        this.crossReferencesToggle?.addEventListener('change', () => this.toggleSetting('showCrossReferences'));
 
         this.verseByVerseToggle?.addEventListener('change', () => this.toggleVerseByVerse());
         this.fontSizeSlider?.addEventListener('input', (e) => this.updateFontSize(e.target.value));
-
-        if (this.translationSelector) {
-            this.translationSelector.addEventListener('change', async (e) => {
-                await this.changeTranslation(e.target.value);
-            });
-        }
+        this.translationSelector?.addEventListener('change', async (e) => this.changeTranslation(e.target.value));
 
         this.themeToggleBtn?.addEventListener('click', () => toggleTheme(this));
-
-        const themeSelector = document.getElementById('themeSelector');
-        const lightModeToggle = document.getElementById('lightModeToggle');
-
-        if (themeSelector) {
-            themeSelector.addEventListener('change', (e) => changeColorTheme(this, e.target.value));
-        }
-        if (lightModeToggle) {
-            lightModeToggle.addEventListener('change', () => toggleTheme(this));
-        }
+        document.getElementById('themeSelector')?.addEventListener('change', (e) => changeColorTheme(this, e.target.value));
+        document.getElementById('lightModeToggle')?.addEventListener('change', () => toggleTheme(this));
 
         this.userBtn?.addEventListener('click', () => this.handleUserButtonClick());
 
@@ -382,27 +337,17 @@ class BibleApp {
             this.closeModal(this.loginModal);
             this.openModal(this.signupModal);
         });
-
         document.getElementById('showLoginLink')?.addEventListener('click', (e) => {
             e.preventDefault();
             this.closeModal(this.signupModal);
             this.openModal(this.loginModal);
         });
-
-        document.getElementById('loginForm')?.addEventListener('submit', (e) => {
-            e.preventDefault();
-            this.handleLogin();
-        });
-
-        document.getElementById('signupForm')?.addEventListener('submit', (e) => {
-            e.preventDefault();
-            this.handleSignup();
-        });
-
+        document.getElementById('loginForm')?.addEventListener('submit', (e) => { e.preventDefault(); this.handleLogin(); });
+        document.getElementById('signupForm')?.addEventListener('submit', (e) => { e.preventDefault(); this.handleSignup(); });
         document.getElementById('logoutBtn')?.addEventListener('click', () => this.handleLogout());
 
-        this.closeLoginModal?.addEventListener('click', () => this.closeModal(this.loginModal));
-        this.closeSignupModal?.addEventListener('click', () => this.closeModal(this.signupModal));
+        this.closeLoginModal?.addEventListener('click',    () => this.closeModal(this.loginModal));
+        this.closeSignupModal?.addEventListener('click',   () => this.closeModal(this.signupModal));
         this.closeUserMenuModal?.addEventListener('click', () => this.closeModal(this.userMenuModal));
 
         window.addEventListener('scroll', () => {
@@ -420,17 +365,16 @@ class BibleApp {
 
     async _loadSavedPositionIfChanged() { await loadSavedPositionIfChanged(this, withTimeout); }
     /** @deprecated Use _loadSavedPositionIfChanged for the auth flow. */
-    async loadSavedReadingPosition() { await loadSavedReadingPosition(this, withTimeout); }
-    saveReadingPosition() { saveReadingPosition(this); }
+    async loadSavedReadingPosition()    { await loadSavedReadingPosition(this, withTimeout); }
+    saveReadingPosition()               { saveReadingPosition(this); }
 
     async loadPassage(book, chapter, restoreScroll = false) {
         if (!restoreScroll) this.saveReadingPosition?.();
 
-        this.state.currentBook = book;
+        this.state.currentBook    = book;
         this.state.currentChapter = chapter;
         this.updateNavigationState();
 
-        const reference = `${book} ${chapter}`;
         this.passageText.innerHTML = '<p class="loading">Loading passage...</p>';
 
         let scaffoldEvents = [];
@@ -442,7 +386,7 @@ class BibleApp {
         }
 
         const data = await this.bibleApi.fetchPassage(
-            reference,
+            `${book} ${chapter}`,
             scaffoldEvents,
             this.state.showHeadings !== false
         );
@@ -453,13 +397,11 @@ class BibleApp {
             return;
         }
 
-        const displayTitle = book === 'Psalm'
+        this.passageTitle.textContent = book === 'Psalm'
             ? `Psalm ${chapter}`
             : `${this.getDisplayName(book)} ${chapter}`;
-        this.passageTitle.textContent = displayTitle;
-        this.passageText.innerHTML = data.passages[0];
-        this.originalPassageHtml = this.passageText.innerHTML;
-
+        this.passageText.innerHTML  = data.passages[0];
+        this.originalPassageHtml    = this.passageText.innerHTML;
         this.passageText.classList.toggle('verse-by-verse', !!this.state.verseByVerse);
 
         this.updateCopyright();
@@ -468,11 +410,7 @@ class BibleApp {
         document.body.classList.add('chrome-no-transition');
         this.showChrome();
 
-        if (restoreScroll) {
-            window.scrollTo(0, this.lastScrollPosition || 0);
-        } else {
-            window.scrollTo(0, 0);
-        }
+        window.scrollTo(0, restoreScroll ? (this.lastScrollPosition || 0) : 0);
 
         requestAnimationFrame(() => {
             this.chromeScrollLastY = window.scrollY || window.pageYOffset || 0;
@@ -487,182 +425,74 @@ class BibleApp {
     // Navigation (delegated)
     // ================================
 
-    navigateChapter(direction) { navChapter(this, direction); }
-    updateNavigationState() { updateNavigationState(this); }
-    navigateToNextVerse() { navigateToNextVerse(this); }
-    navigateToPreviousVerse() { navigateToPreviousVerse(this); }
+    navigateChapter(direction)  { navChapter(this, direction); }
+    updateNavigationState()     { updateNavigationState(this); }
+    navigateToNextVerse()       { navigateToNextVerse(this); }
+    navigateToPreviousVerse()   { navigateToPreviousVerse(this); }
 
     // ================================
     // Search (delegated)
     // ================================
 
-    toggleSearch() { toggleSearch(this); }
-    closeSearch() { closeSearch(this); }
-    handleSearch(query) { handleSearch(this, query); }
-    handleSearchKeydown(e) { handleSearchKeydown(this, e); }
-    refreshSearchResultItems(autoSelectFirst) { refreshSearchResultItems(this, autoSelectFirst); }
-    setSearchSelectedIndex(index, scrollIntoView) { setSearchSelectedIndex(this, index, scrollIntoView); }
-    activateSelectedSearchResult() { activateSelectedSearchResult(this); }
-    isPassageReference(query) { return isPassageReference(query); }
-    async handlePassageReference(reference) { await handlePassageReference(this, reference); }
-    async fetchAllSearchResults(query, onBatch) { return fetchAllSearchResults(this, query, onBatch); }
-    groupSearchResultsByCanon(results) { return groupSearchResultsByCanon(this, results); }
-    async performKeywordSearch(query) { await performKeywordSearch(this, query); }
-    displaySearchResults(results, query) { displaySearchResults(this, results, query); }
-    parseReference(reference) { return parseReference(reference); }
-    async loadPassageFromReference(reference) { await loadPassageFromReference(this, reference); }
-    escapeRegExp(str) { return escapeRegExp(str); }
-    highlightSearchTerm(text, term) { return highlightSearchTerm(text, term); }
-    stripHTML(html) { return stripHTML(html); }
+    toggleSearch()                          { toggleSearch(this); }
+    closeSearch()                           { closeSearch(this); }
+    handleSearch(query)                     { handleSearch(this, query); }
+    handleSearchKeydown(e)                  { handleSearchKeydown(this, e); }
+    refreshSearchResultItems(autoSelect)    { refreshSearchResultItems(this, autoSelect); }
+    setSearchSelectedIndex(i, scroll)       { setSearchSelectedIndex(this, i, scroll); }
+    activateSelectedSearchResult()          { activateSelectedSearchResult(this); }
+    isPassageReference(q)                   { return isPassageReference(q); }
+    async handlePassageReference(ref)       { await handlePassageReference(this, ref); }
+    async fetchAllSearchResults(q, onBatch) { return fetchAllSearchResults(this, q, onBatch); }
+    groupSearchResultsByCanon(results)      { return groupSearchResultsByCanon(this, results); }
+    async performKeywordSearch(q)           { await performKeywordSearch(this, q); }
+    displaySearchResults(results, q)        { displaySearchResults(this, results, q); }
+    parseReference(ref)                     { return parseReference(ref); }
+    async loadPassageFromReference(ref)     { await loadPassageFromReference(this, ref); }
+    escapeRegExp(str)                       { return escapeRegExp(str); }
+    highlightSearchTerm(text, term)         { return highlightSearchTerm(text, term); }
+    stripHTML(html)                         { return stripHTML(html); }
 
     // ================================
     // Modals (delegated)
     // ================================
 
-    openModal(modal) { openModal(this, modal); }
-    closeModal(modal) { closeModal(this, modal); }
-    openBookModal() { openBookModal(this); }
-    populateBookModal() { populateBookModal(this); }
-    openChapterModal() { openChapterModal(this); }
-    populateChapterModal() { populateChapterModal(this); }
-    openVerseModal() { openVerseModal(this); }
-    populateVerseModal() { populateVerseModal(this); }
-    getCurrentVerseCount() { return getCurrentVerseCount(this); }
-
-    scrollToVerse(verseNumber) { scrollVerse(this, verseNumber); }
-    applyVerseGlow() { glowVerse(this); }
+    openModal(modal)          { openModal(this, modal); }
+    closeModal(modal)         { closeModal(this, modal); }
+    openBookModal()           { openBookModal(this); }
+    populateBookModal()       { populateBookModal(this); }
+    openChapterModal()        { openChapterModal(this); }
+    populateChapterModal()    { populateChapterModal(this); }
+    openVerseModal()          { openVerseModal(this); }
+    populateVerseModal()      { populateVerseModal(this); }
+    getCurrentVerseCount()    { return getCurrentVerseCount(this); }
+    scrollToVerse(n)          { scrollVerse(this, n); }
+    applyVerseGlow()          { glowVerse(this); }
 
     // ================================
-    // Settings
+    // Settings (delegated)
     // ================================
 
-    checkApiKey() { checkApiKey(this); }
-
-    loadLocalSettings() {
-        try { this.state.fontSize = parseInt(localStorage.getItem('fontSize') || '18', 10); } catch (_) { this.state.fontSize = 18; }
-        this.state.showVerseNumbers     = readBool('showVerseNumbers',   true);
-        this.state.showHeadings         = readBool('showHeadings',       true);
-        this.state.showFootnotes        = readBool('showFootnotes',      false);
-        this.state.showCrossReferences  = readBool('showCrossReferences', false);
-        this.state.verseByVerse         = readBool('verseByVerse',       false);
-        this.state.lightMode            = readBool('lightMode',          false);
-        try { this.state.colorTheme = localStorage.getItem('colorTheme') || 'dracula'; } catch (_) { this.state.colorTheme = 'dracula'; }
-        try { this.state.translation = normalizeTranslation(localStorage.getItem('translation') || 'ESV'); } catch (_) { this.state.translation = 'ESV'; }
-    }
-
-    applySettings() {
-        const themeSelector = document.getElementById('themeSelector');
-        if (themeSelector && this.state.colorTheme) themeSelector.value = this.state.colorTheme;
-        changeColorTheme(this, this.state.colorTheme || 'dracula');
-
-        if (this.translationSelector && this.state.translation) {
-            this.translationSelector.value = this.state.translation;
-        }
-        this.bibleApi.setTranslation(this.state.translation || 'ESV');
-
-        document.body.classList.toggle('light-mode', !!this.state.lightMode);
-        const lightModeToggle = document.getElementById('lightModeToggle');
-        if (lightModeToggle) lightModeToggle.checked = !!this.state.lightMode;
-        updateThemeIcon(this.state.lightMode);
-
-        document.body.classList.toggle('hide-verse-numbers', !this.state.showVerseNumbers);
-        if (this.verseNumbersToggle) this.verseNumbersToggle.checked = !!this.state.showVerseNumbers;
-        if (this.headingsToggle) this.headingsToggle.checked = !!this.state.showHeadings;
-        if (this.footnotesToggle) this.footnotesToggle.checked = !!this.state.showFootnotes;
-        if (this.crossReferencesToggle) this.crossReferencesToggle.checked = !!this.state.showCrossReferences;
-
-        if (this.passageText) this.passageText.classList.toggle('verse-by-verse', !!this.state.verseByVerse);
-        if (this.verseByVerseToggle) this.verseByVerseToggle.checked = !!this.state.verseByVerse;
-
-        const fontSize = this.state.fontSize || 18;
-        if (this.fontSizeSlider) this.fontSizeSlider.value = fontSize;
-        if (this.fontSizeValue) this.fontSizeValue.textContent = `${fontSize}px`;
-        if (this.passageText) this.passageText.style.fontSize = `${fontSize}px`;
-
-        this.updateCopyright();
-    }
-
-    async toggleSetting(setting) {
-        const toggleMap = {
-            showVerseNumbers:    'verseNumbersToggle',
-            showHeadings:        'headingsToggle',
-            showFootnotes:       'footnotesToggle',
-            showCrossReferences: 'crossReferencesToggle',
-        };
-        const toggleElement = this[toggleMap[setting]];
-        if (!toggleElement) return;
-        this.state[setting] = toggleElement.checked;
-
-        if (this.currentUser) {
-            await this.database.ref(`users/${this.currentUser.uid}/settings/${setting}`).set(toggleElement.checked);
-        } else {
-            try { localStorage.setItem(setting, String(toggleElement.checked)); } catch (_) {}
-        }
-
-        if (setting === 'showHeadings') {
-            await this.loadPassage(this.state.currentBook, this.state.currentChapter);
-            return;
-        }
-
-        this.applySettings();
-    }
-
-    async toggleVerseByVerse() {
-        this.state.verseByVerse = this.verseByVerseToggle.checked;
-        if (this.currentUser) {
-            await this.database.ref(`users/${this.currentUser.uid}/settings/verseByVerse`).set(this.state.verseByVerse);
-        } else {
-            try { localStorage.setItem('verseByVerse', String(this.state.verseByVerse)); } catch (_) {}
-        }
-        this.passageText.classList.toggle('verse-by-verse', this.state.verseByVerse);
-    }
-
-    async updateFontSize(size) {
-        this.state.fontSize = parseInt(size, 10);
-        this.fontSizeValue.textContent = `${size}px`;
-        this.passageText.style.fontSize = `${size}px`;
-        if (this.currentUser) {
-            await this.database.ref(`users/${this.currentUser.uid}/settings/fontSize`).set(parseInt(size, 10));
-        } else {
-            try { localStorage.setItem('fontSize', size); } catch (_) {}
-        }
-    }
-
-    async changeTranslation(translation) {
-        this.state.translation = translation;
-        this.bibleApi.setTranslation(translation);
-
-        if (this.currentUser) {
-            await this.database.ref(`users/${this.currentUser.uid}/settings/translation`).set(translation);
-        } else {
-            try { localStorage.setItem('translation', translation); } catch (_) {}
-        }
-
-        this.updateCopyright();
-        await this.loadPassage(this.state.currentBook, this.state.currentChapter);
-    }
-
-    updateCopyright() {
-        if (this.copyright) {
-            this.copyright.textContent = this._copyrightMap[this.state.translation] || '';
-        }
-    }
+    loadLocalSettings()                    { loadLocalSettings(this); }
+    applySettings()                        { applySettings(this); }
+    async toggleSetting(s)                 { await toggleSetting(this, s); }
+    async toggleVerseByVerse()             { await toggleVerseByVerse(this); }
+    async updateFontSize(size)             { await updateFontSize(this, size); }
+    async changeTranslation(t)             { await changeTranslation(this, t); }
+    updateCopyright()                      { updateCopyright(this); }
 
     // ================================
     // Utilities
     // ================================
 
-    copyPassage() {
-        const textContent = this.stripHTML(this.passageText.innerHTML);
-        const reference = this.passageTitle.textContent;
-        const fullText = `${reference}\n\n${textContent}\n\n${this.copyright?.textContent ?? ''}`;
+    checkApiKey() { checkApiKey(this); }
 
-        navigator.clipboard.writeText(fullText)
+    copyPassage() {
+        const text = this.stripHTML(this.passageText.innerHTML);
+        const ref  = this.passageTitle.textContent;
+        navigator.clipboard.writeText(`${ref}\n\n${text}\n\n${this.copyright?.textContent ?? ''}`)
             .then(() => this.showToast('Passage copied to clipboard!'))
-            .catch((err) => {
-                console.error('Failed to copy:', err);
-                this.showToast('Failed to copy passage');
-            });
+            .catch((err) => { console.error('Failed to copy:', err); this.showToast('Failed to copy passage'); });
     }
 
     showError(message) {
@@ -683,63 +513,50 @@ class BibleApp {
         }
 
         if (e.key === 'Escape') {
-            if (this.bookModal?.classList.contains('active'))       this.closeModal(this.bookModal);
-            if (this.chapterModal?.classList.contains('active'))    this.closeModal(this.chapterModal);
-            if (this.helpModal?.classList.contains('active'))       this.closeModal(this.helpModal);
-            if (this.settingsModal?.classList.contains('active'))   this.closeModal(this.settingsModal);
-            if (this.loginModal?.classList.contains('active'))      this.closeModal(this.loginModal);
-            if (this.signupModal?.classList.contains('active'))     this.closeModal(this.signupModal);
-            if (this.userMenuModal?.classList.contains('active'))   this.closeModal(this.userMenuModal);
+            const modals = [
+                this.bookModal, this.chapterModal, this.helpModal,
+                this.settingsModal, this.loginModal, this.signupModal,
+                this.userMenuModal, this.verseModal, this.referencesModal,
+            ];
+            modals.forEach((m) => { if (m?.classList.contains('active')) this.closeModal(m); });
             if (this.searchContainer?.classList.contains('active')) this.closeSearch();
-            if (this.verseModal?.classList.contains('active'))      this.closeModal(this.verseModal);
-            if (this.referencesModal?.classList.contains('active')) this.closeModal(this.referencesModal);
         }
 
         if (!document.querySelector('.modal.active') && !this.searchContainer?.classList.contains('active')) {
-            if (e.key === 'ArrowLeft' || e.key === 'h') {
-                e.preventDefault();
-                this.navigateChapter(-1);
-            } else if (e.key === 'ArrowRight' || e.key === 'l') {
-                e.preventDefault();
-                this.navigateChapter(1);
-            } else if (e.key === 'ArrowUp' || e.key === 'k') {
-                e.preventDefault();
-                this.navigateToPreviousVerse();
-            } else if (e.key === 'ArrowDown' || e.key === 'j') {
-                e.preventDefault();
-                this.navigateToNextVerse();
-            } else if (e.key === 'v') {
+            if      (e.key === 'ArrowLeft'  || e.key === 'h') { e.preventDefault(); this.navigateChapter(-1); }
+            else if (e.key === 'ArrowRight' || e.key === 'l') { e.preventDefault(); this.navigateChapter(1); }
+            else if (e.key === 'ArrowUp'    || e.key === 'k') { e.preventDefault(); this.navigateToPreviousVerse(); }
+            else if (e.key === 'ArrowDown'  || e.key === 'j') { e.preventDefault(); this.navigateToNextVerse(); }
+            else if (e.key === 'v') {
                 e.preventDefault();
                 this.verseByVerseToggle.checked = !this.verseByVerseToggle.checked;
                 this.toggleVerseByVerse();
-            } else if (e.key === 's') {
+            } else if (e.key === 's' && this.headingsToggle) {
                 e.preventDefault();
-                if (this.headingsToggle) {
-                    this.headingsToggle.checked = !this.headingsToggle.checked;
-                    this.toggleSetting('showHeadings');
-                }
+                this.headingsToggle.checked = !this.headingsToggle.checked;
+                this.toggleSetting('showHeadings');
             }
         }
     }
 
     // ================================
-    // Firebase Authentication (delegated)
+    // Firebase Auth (delegated)
     // ================================
 
-    handleUserButtonClick() { handleUserButtonClick(this); }
-    async handleLogin() { await handleLogin(this); }
-    async handleSignup() { await handleSignup(this); }
-    async handleLogout() { await handleLogout(this); }
-    async loadUserData() { await loadUserData(this, normalizeTranslation); }
+    handleUserButtonClick()  { handleUserButtonClick(this); }
+    async handleLogin()      { await handleLogin(this); }
+    async handleSignup()     { await handleSignup(this); }
+    async handleLogout()     { await handleLogout(this); }
+    async loadUserData()     { await loadUserData(this, normalizeTranslation); }
 }
 
 
 /* ─── Service Worker & Update Toast ─── */
+
 async function registerServiceWorker(appInstance) {
     if (!('serviceWorker' in navigator)) return;
     try {
         const reg = await navigator.serviceWorker.register('./sw.js', { scope: './' });
-
         const buildMeta = document.querySelector('meta[name="build-id"]')?.content || '__BUILD_ID__';
         console.info('[BUILD_ID]', buildMeta);
 
@@ -749,9 +566,8 @@ async function registerServiceWorker(appInstance) {
         });
 
         document.addEventListener('visibilitychange', () => {
-            if (document.visibilityState === 'visible') {
+            if (document.visibilityState === 'visible')
                 reg.update().catch((err) => console.warn('SW update check failed', err));
-            }
         });
     } catch (err) {
         console.warn('SW registration failed', err);
@@ -763,23 +579,16 @@ function showUpdateToast(appInstance) {
     if (!toast) return;
     toast.innerHTML = '';
 
-    const text = document.createElement('span');
-    text.textContent = 'A new version is available.';
+    const text = Object.assign(document.createElement('span'), { textContent: 'A new version is available.' });
     text.style.flex = '1';
 
-    const action = document.createElement('button');
-    action.textContent = 'Refresh';
-    action.className = 'toast-action';
+    const action = Object.assign(document.createElement('button'), { textContent: 'Refresh', className: 'toast-action' });
     action.addEventListener('click', () => location.reload());
 
-    const dismiss = document.createElement('button');
-    dismiss.textContent = '\u00d7';
-    dismiss.className = 'toast-dismiss';
+    const dismiss = Object.assign(document.createElement('button'), { textContent: '\u00d7', className: 'toast-dismiss' });
     dismiss.addEventListener('click', () => toast.classList.remove('show'));
 
-    toast.appendChild(text);
-    toast.appendChild(action);
-    toast.appendChild(dismiss);
+    toast.append(text, action, dismiss);
     toast.classList.add('show');
     setTimeout(() => toast.classList.remove('show'), 30000);
 }
@@ -789,10 +598,7 @@ function showUpdateToast(appInstance) {
         if (document.readyState !== 'loading') return resolve();
         document.addEventListener('DOMContentLoaded', resolve, { once: true });
     });
-    try {
-        await import('./config/firebase-config.js');
-    } catch (err) {
-        console.error('Firebase config module failed to load:', err);
-    }
+    try { await import('./config/firebase-config.js'); }
+    catch (err) { console.error('Firebase config module failed to load:', err); }
     new BibleApp();
 })();

--- a/app.js
+++ b/app.js
@@ -18,6 +18,13 @@ import {
     updateThemeIcon,
     changeColorTheme,
 } from './ui.js';
+import {
+    initializeBibleStructure,
+    getAllBooks,
+    getChapterCount,
+    getTestament,
+    getDisplayName,
+} from './bible-structure.js';
 
 function readBool(key, defaultValue) {
     try {
@@ -52,7 +59,7 @@ class BibleApp {
 
         this._copyrightMap = {};
 
-        this.bibleBooks = this.initializeBibleStructure();
+        this.bibleBooks = initializeBibleStructure();
 
         this.bookAbbreviations = {
             Genesis: 'Gen', Exodus: 'Exod', Leviticus: 'Lev', Numbers: 'Num', Deuteronomy: 'Deut',
@@ -138,56 +145,23 @@ class BibleApp {
     }
 
     // ================================
-    // Bible Structure
+    // Bible Structure (delegated)
     // ================================
 
-    initializeBibleStructure() {
-        return {
-            'Old Testament': {
-                Genesis: 50, Exodus: 40, Leviticus: 27, Numbers: 36, Deuteronomy: 34,
-                Joshua: 24, Judges: 21, Ruth: 4, '1 Samuel': 31, '2 Samuel': 24,
-                '1 Kings': 22, '2 Kings': 25, '1 Chronicles': 29, '2 Chronicles': 36,
-                Ezra: 10, Nehemiah: 13, Esther: 10, Job: 42, Psalm: 150, Proverbs: 31,
-                Ecclesiastes: 12, 'Song of Solomon': 8, Isaiah: 66, Jeremiah: 52,
-                Lamentations: 5, Ezekiel: 48, Daniel: 12, Hosea: 14, Joel: 3, Amos: 9,
-                Obadiah: 1, Jonah: 4, Micah: 7, Nahum: 3, Habakkuk: 3, Zephaniah: 3,
-                Haggai: 2, Zechariah: 14, Malachi: 4,
-            },
-            'New Testament': {
-                Matthew: 28, Mark: 16, Luke: 24, John: 21, Acts: 28, Romans: 16,
-                '1 Corinthians': 16, '2 Corinthians': 13, Galatians: 6, Ephesians: 6,
-                Philippians: 4, Colossians: 4, '1 Thessalonians': 5, '2 Thessalonians': 3,
-                '1 Timothy': 6, '2 Timothy': 4, Titus: 3, Philemon: 1, Hebrews: 13,
-                James: 5, '1 Peter': 5, '2 Peter': 3, '1 John': 5, '2 John': 1,
-                '3 John': 1, Jude: 1, Revelation: 22,
-            },
-        };
-    }
-
     getAllBooks() {
-        return [
-            ...Object.keys(this.bibleBooks['Old Testament']),
-            ...Object.keys(this.bibleBooks['New Testament']),
-        ];
+        return getAllBooks(this);
     }
 
     getChapterCount(book) {
-        for (const testament in this.bibleBooks) {
-            if (this.bibleBooks[testament][book]) {
-                return this.bibleBooks[testament][book];
-            }
-        }
-        return 0;
+        return getChapterCount(this, book);
     }
 
     getTestament(book) {
-        if (this.bibleBooks['Old Testament'][book]) return 'Old Testament';
-        if (this.bibleBooks['New Testament'][book]) return 'New Testament';
-        return null;
+        return getTestament(this, book);
     }
 
     getDisplayName(book) {
-        return this.bookDisplayNames[book] || book;
+        return getDisplayName(this, book);
     }
 
     // ================================
@@ -862,10 +836,6 @@ class BibleApp {
         }
     }
 
-    /**
-     * Runs a full-Bible keyword search, streaming results into the UI as each
-     * batch of books resolves. Returns the complete result array when done.
-     */
     async fetchAllSearchResults(query, onBatch) {
         this.currentSearchResults = [];
         await this.bibleApi.searchPassages(query, (batchResults) => {
@@ -925,15 +895,12 @@ class BibleApp {
         this.searchExpandedTestaments?.clear();
         this.searchExpandedBooks?.clear();
 
-        // Stream results into the UI as each batch of books resolves.
         await this.fetchAllSearchResults(query, (accumulatedResults) => {
             if (accumulatedResults.length > 0) {
                 this.displaySearchResults(accumulatedResults, query);
             }
         });
 
-        // Final render — ensures the completed result set is shown even if the
-        // last batch produced no new matches (callback would not have fired).
         if (this.currentSearchResults.length > 0) {
             this.displaySearchResults(this.currentSearchResults, query);
         } else {

--- a/app.js
+++ b/app.js
@@ -35,13 +35,14 @@ import {
     openBookModal, populateBookModal,
     openChapterModal, populateChapterModal,
     openVerseModal, populateVerseModal,
-    getCurrentVerseCount, attachDragToResize,
+    getCurrentVerseCount,
 } from './modals.js';
 import {
     loadLocalSettings, applySettings, toggleSetting,
     toggleVerseByVerse, updateFontSize, changeTranslation, updateCopyright,
 } from './settings.js';
 import { handleKeyboardShortcuts } from './keyboard.js';
+import { attachEventListeners } from './events.js';
 
 const TRANSLATION_ALIASES = { NRSVue: 'NRSVUE' };
 function normalizeTranslation(t) { return TRANSLATION_ALIASES[t] || t; }
@@ -116,7 +117,7 @@ class BibleApp {
                 return;
             }
             window.requestAnimationFrame(() => {
-                const y = window.scrollY || window.pageYOffset || 0;
+                const y     = window.scrollY || window.pageYOffset || 0;
                 const delta = y - this.chromeScrollLastY;
                 const modalOpen  = !!document.querySelector('.modal.active');
                 const searchOpen = !!this.searchContainer?.classList.contains('active');
@@ -167,7 +168,7 @@ class BibleApp {
         }
         if (lightModeToggle) lightModeToggle.checked = document.body.classList.contains('light-mode');
 
-        this.attachEventListeners();
+        attachEventListeners(this);
         this.initializeAccordion();
         document.body.setAttribute('data-app-ready', 'true');
 
@@ -221,90 +222,6 @@ class BibleApp {
                 this.openModal(this.currentUser ? this.userMenuModal : this.loginModal);
             });
         }
-    }
-
-    attachEventListeners() {
-        this.searchToggleBtn?.addEventListener('click', () => this.toggleSearch());
-        this.helpBtn?.addEventListener('click',     () => this.openModal(this.helpModal));
-        this.settingsBtn?.addEventListener('click', () => this.openModal(this.settingsModal));
-
-        this.closeSearchBtn?.addEventListener('click', () => this.closeSearch());
-        this.searchInput?.addEventListener('input',   (e) => this.handleSearch(e.target.value));
-        this.searchInput?.addEventListener('keydown', (e) => this.handleSearchKeydown(e));
-
-        this.prevChapterBtn?.addEventListener('click', () => this.navigateChapter(-1));
-        this.nextChapterBtn?.addEventListener('click', () => this.navigateChapter(1));
-        this.bookSelector?.addEventListener('click',   () => this.openBookModal());
-        this.chapterSelector?.addEventListener('click',() => this.openChapterModal());
-        this.verseSelector?.addEventListener('click',  () => this.openVerseModal());
-        this.closeVerseModal?.addEventListener('click',() => this.closeModal(this.verseModal));
-
-        this.referencesModal        = document.getElementById('referencesModal');
-        this.closeReferencesModal   = document.getElementById('closeReferencesModal');
-        this.footnotesSection       = document.getElementById('footnotesSection');
-        this.footnotesContent       = document.getElementById('footnotesContent');
-        this.crossReferencesSection = document.getElementById('crossReferencesSection');
-        this.crossReferencesContent = document.getElementById('crossReferencesContent');
-
-        [
-            this.bookModal, this.chapterModal, this.verseModal,
-            this.settingsModal, this.helpModal, this.loginModal,
-            this.signupModal, this.userMenuModal, this.referencesModal,
-        ].forEach((modal) => {
-            if (!modal) return;
-            modal.addEventListener('click', (e) => { if (e.target === modal) this.closeModal(modal); });
-        });
-
-        this.closeBookModal?.addEventListener('click',       () => this.closeModal(this.bookModal));
-        this.closeChapterModal?.addEventListener('click',    () => this.closeModal(this.chapterModal));
-        this.closeHelpModal?.addEventListener('click',       () => this.closeModal(this.helpModal));
-        this.closeSettingsModal?.addEventListener('click',   () => this.closeModal(this.settingsModal));
-        this.closeReferencesModal?.addEventListener('click', () => this.closeModal(this.referencesModal));
-
-        attachDragToResize(this);
-
-        this.verseNumbersToggle?.addEventListener('change', () => this.toggleSetting('showVerseNumbers'));
-        this.headingsToggle?.addEventListener('change',     () => this.toggleSetting('showHeadings'));
-        this.footnotesToggle?.addEventListener('change',    () => this.toggleSetting('showFootnotes'));
-
-        this.crossReferencesToggle = document.getElementById('crossReferencesToggle');
-        this.crossReferencesToggle?.addEventListener('change', () => this.toggleSetting('showCrossReferences'));
-
-        this.verseByVerseToggle?.addEventListener('change', () => this.toggleVerseByVerse());
-        this.fontSizeSlider?.addEventListener('input',  (e) => this.updateFontSize(e.target.value));
-        this.translationSelector?.addEventListener('change', async (e) => this.changeTranslation(e.target.value));
-
-        this.themeToggleBtn?.addEventListener('click', () => toggleTheme(this));
-        document.getElementById('themeSelector')?.addEventListener('change',   (e) => changeColorTheme(this, e.target.value));
-        document.getElementById('lightModeToggle')?.addEventListener('change', () => toggleTheme(this));
-
-        this.userBtn?.addEventListener('click', () => this.handleUserButtonClick());
-
-        document.getElementById('showSignupLink')?.addEventListener('click', (e) => {
-            e.preventDefault();
-            this.closeModal(this.loginModal);
-            this.openModal(this.signupModal);
-        });
-        document.getElementById('showLoginLink')?.addEventListener('click', (e) => {
-            e.preventDefault();
-            this.closeModal(this.signupModal);
-            this.openModal(this.loginModal);
-        });
-        document.getElementById('loginForm')?.addEventListener('submit',  (e) => { e.preventDefault(); this.handleLogin(); });
-        document.getElementById('signupForm')?.addEventListener('submit', (e) => { e.preventDefault(); this.handleSignup(); });
-        document.getElementById('logoutBtn')?.addEventListener('click', () => this.handleLogout());
-
-        this.closeLoginModal?.addEventListener('click',    () => this.closeModal(this.loginModal));
-        this.closeSignupModal?.addEventListener('click',   () => this.closeModal(this.signupModal));
-        this.closeUserMenuModal?.addEventListener('click', () => this.closeModal(this.userMenuModal));
-
-        window.addEventListener('scroll', () => {
-            this.handleChromeScroll();
-            clearTimeout(this.scrollTimeout);
-            this.scrollTimeout = setTimeout(() => this.saveReadingPosition(), 500);
-        }, { passive: true });
-
-        document.addEventListener('keydown', (e) => this.handleKeyboardShortcuts(e));
     }
 
     // ==========================================

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,213 @@
+// auth.js
+// Firebase auth, user data, and reading-position persistence for BibleApp.
+
+import { loadUserData as loadUserDataFromFirebase } from './config/firebase-config.js';
+
+export async function loadSavedPositionIfChanged(app, withTimeout) {
+    if (!app.currentUser || !app.database) return;
+
+    let targetBook = app.state.currentBook;
+    let targetChapter = app.state.currentChapter;
+    let targetScrollY = 0;
+
+    try {
+        const snapshot = await withTimeout(
+            app.database.ref(`users/${app.currentUser.uid}/readingPosition`).once('value'),
+            5000
+        );
+
+        if (snapshot) {
+            const pos = snapshot.val();
+            if (pos && pos.book && pos.chapter) {
+                targetBook = pos.book;
+                targetChapter = pos.chapter;
+                targetScrollY = pos.scrollY || 0;
+            }
+        } else {
+            console.warn('_loadSavedPositionIfChanged: timed out, keeping current passage');
+        }
+    } catch (err) {
+        console.error('_loadSavedPositionIfChanged: Firebase read failed', err);
+    }
+
+    if (targetBook !== app.state.currentBook || targetChapter !== app.state.currentChapter) {
+        app.state.currentBook = targetBook;
+        app.state.currentChapter = targetChapter;
+        app.lastScrollPosition = targetScrollY;
+        await app.loadPassage(targetBook, targetChapter, !!targetScrollY);
+    } else if (targetScrollY) {
+        window.scrollTo(0, targetScrollY);
+    }
+}
+
+/** @deprecated Use loadSavedPositionIfChanged for the auth flow. */
+export async function loadSavedReadingPosition(app, withTimeout) {
+    if (!app.currentUser || !app.database) {
+        await app.loadPassage(app.state.currentBook, app.state.currentChapter);
+        return;
+    }
+
+    try {
+        const snapshot = await withTimeout(
+            app.database.ref(`users/${app.currentUser.uid}/readingPosition`).once('value'),
+            5000
+        );
+
+        if (snapshot) {
+            const pos = snapshot.val();
+            if (pos && pos.book && pos.chapter) {
+                app.state.currentBook = pos.book;
+                app.state.currentChapter = pos.chapter;
+                app.lastScrollPosition = pos.scrollY || 0;
+            }
+        } else {
+            console.warn('loadSavedReadingPosition: timed out, loading from local state');
+        }
+    } catch (err) {
+        console.error('loadSavedReadingPosition: failed to read Firebase', err);
+    }
+
+    await app.loadPassage(app.state.currentBook, app.state.currentChapter, !!app.lastScrollPosition);
+}
+
+export function saveReadingPosition(app) {
+    if (!app.currentUser || !app.database) return;
+
+    const pos = {
+        book: app.state.currentBook,
+        chapter: app.state.currentChapter,
+        scrollY: window.scrollY || 0,
+    };
+
+    app.database
+        .ref(`users/${app.currentUser.uid}/readingPosition`)
+        .set(pos)
+        .catch((err) => console.error('saveReadingPosition: Firebase write failed', err));
+}
+
+export function checkApiKey(app) {
+    setTimeout(() => {
+        app.showToast('Sign in to sync your reading position across devices.');
+    }, 500);
+}
+
+export function handleUserButtonClick(app) {
+    if (app.currentUser) {
+        document.getElementById('userEmail').textContent = app.currentUser.email;
+        const isLight = document.body.classList.contains('light-mode');
+        let colorTheme = app.state?.colorTheme || 'dracula';
+
+        try { colorTheme = app.state?.colorTheme || localStorage.getItem('colorTheme') || 'dracula'; } catch (_) {}
+        const themeNameMap = {
+            dracula: isLight ? 'Alucard (Light)' : 'Dracula (Dark)',
+            steel:   `Steel (${isLight ? 'Light' : 'Dark'})`,
+            onyx:    `Onyx (${isLight ? 'Light' : 'Dark'})`,
+            reader:  `Reader (${isLight ? 'Parchment' : 'Night'})`,
+        };
+        document.getElementById('userTheme').textContent =
+            themeNameMap[colorTheme] || (isLight ? 'Alucard (Light)' : 'Dracula (Dark)');
+        app.openModal(app.userMenuModal);
+    } else {
+        app.openModal(app.loginModal);
+    }
+}
+
+export async function handleLogin(app) {
+    const email = document.getElementById('loginEmail').value;
+    const password = document.getElementById('loginPassword').value;
+
+    if (!email || !password) {
+        app.showToast('Please enter valid credentials');
+        return;
+    }
+
+    try {
+        await app.auth.signInWithEmailAndPassword(email, password);
+        app.showToast('Signed in successfully!');
+        app.closeModal(app.loginModal);
+        document.getElementById('loginEmail').value = '';
+        document.getElementById('loginPassword').value = '';
+    } catch (error) {
+        console.error('Login error:', error);
+        if (error.code === 'auth/user-not-found') {
+            if (confirm('No account found with this email. Sign up instead?')) {
+                app.closeModal(app.loginModal);
+                app.openModal(app.signupModal);
+                document.getElementById('signupEmail').value = email;
+            }
+        } else if (error.code === 'auth/wrong-password') {
+            app.showToast('Incorrect password');
+        } else {
+            app.showToast(`Login failed: ${error.message}`);
+        }
+    }
+}
+
+export async function handleSignup(app) {
+    const email = document.getElementById('signupEmail').value;
+    const password = document.getElementById('signupPassword').value;
+
+    if (!email || !password) {
+        app.showToast('Please fill in all fields');
+        return;
+    }
+
+    if (password.length < 6) {
+        app.showToast('Password must be at least 6 characters');
+        return;
+    }
+
+    try {
+        const userCredential = await app.auth.createUserWithEmailAndPassword(email, password);
+        const user = userCredential.user;
+
+        await app.database.ref(`users/${user.uid}/settings`).set({
+            fontSize: app.state.fontSize,
+            showVerseNumbers: app.state.showVerseNumbers,
+            showHeadings: app.state.showHeadings,
+            showFootnotes: app.state.showFootnotes,
+            showCrossReferences: app.state.showCrossReferences,
+            verseByVerse: app.state.verseByVerse,
+            colorTheme: app.state.colorTheme,
+            lightMode: app.state.lightMode,
+            translation: app.state.translation || 'ESV',
+        });
+
+        app.showToast('Account created successfully!');
+        app.closeModal(app.signupModal);
+    } catch (error) {
+        console.error('Signup error:', error);
+        if (error.code === 'auth/email-already-in-use') {
+            app.showToast('An account with this email already exists');
+        } else {
+            app.showToast(`Signup failed: ${error.message}`);
+        }
+    }
+}
+
+export async function handleLogout(app) {
+    try {
+        await app.auth.signOut();
+        app.showToast('Signed out successfully');
+        app.closeModal(app.userMenuModal);
+    } catch (error) {
+        console.error('Logout error:', error);
+        app.showToast('Failed to sign out');
+    }
+}
+
+export async function loadUserData(app, normalizeTranslation) {
+    if (!app.currentUser) return;
+    const data = await loadUserDataFromFirebase(app.currentUser.uid);
+    if (!data) return;
+    const s = data.settings;
+    app.state.fontSize             = s.fontSize;
+    app.state.showVerseNumbers     = s.showVerseNumbers;
+    app.state.showHeadings         = s.showHeadings;
+    app.state.showFootnotes        = s.showFootnotes;
+    app.state.showCrossReferences  = s.showCrossReferences;
+    app.state.verseByVerse         = s.verseByVerse;
+    app.state.colorTheme           = s.colorTheme;
+    app.state.lightMode            = s.lightMode;
+    app.state.translation          = normalizeTranslation(s.translation || 'ESV');
+}

--- a/bible-structure.js
+++ b/bible-structure.js
@@ -1,0 +1,80 @@
+// bible-structure.js
+// Bible canon data and book-level lookup helpers.
+// All functions accept an `app` instance as their first argument so they can
+// read app.bibleBooks and app.bookDisplayNames without coupling to BibleApp.
+
+/**
+ * Returns the full OT/NT structure object: { testament: { book: chapterCount } }
+ * Called once during BibleApp construction; result stored on app.bibleBooks.
+ */
+export function initializeBibleStructure() {
+    return {
+        'Old Testament': {
+            Genesis: 50, Exodus: 40, Leviticus: 27, Numbers: 36, Deuteronomy: 34,
+            Joshua: 24, Judges: 21, Ruth: 4, '1 Samuel': 31, '2 Samuel': 24,
+            '1 Kings': 22, '2 Kings': 25, '1 Chronicles': 29, '2 Chronicles': 36,
+            Ezra: 10, Nehemiah: 13, Esther: 10, Job: 42, Psalm: 150, Proverbs: 31,
+            Ecclesiastes: 12, 'Song of Solomon': 8, Isaiah: 66, Jeremiah: 52,
+            Lamentations: 5, Ezekiel: 48, Daniel: 12, Hosea: 14, Joel: 3, Amos: 9,
+            Obadiah: 1, Jonah: 4, Micah: 7, Nahum: 3, Habakkuk: 3, Zephaniah: 3,
+            Haggai: 2, Zechariah: 14, Malachi: 4,
+        },
+        'New Testament': {
+            Matthew: 28, Mark: 16, Luke: 24, John: 21, Acts: 28, Romans: 16,
+            '1 Corinthians': 16, '2 Corinthians': 13, Galatians: 6, Ephesians: 6,
+            Philippians: 4, Colossians: 4, '1 Thessalonians': 5, '2 Thessalonians': 3,
+            '1 Timothy': 6, '2 Timothy': 4, Titus: 3, Philemon: 1, Hebrews: 13,
+            James: 5, '1 Peter': 5, '2 Peter': 3, '1 John': 5, '2 John': 1,
+            '3 John': 1, Jude: 1, Revelation: 22,
+        },
+    };
+}
+
+/**
+ * Returns a flat ordered array of all book names (OT then NT).
+ * @param {object} app
+ * @returns {string[]}
+ */
+export function getAllBooks(app) {
+    return [
+        ...Object.keys(app.bibleBooks['Old Testament']),
+        ...Object.keys(app.bibleBooks['New Testament']),
+    ];
+}
+
+/**
+ * Returns the number of chapters in `book`, or 0 if not found.
+ * @param {object} app
+ * @param {string} book
+ * @returns {number}
+ */
+export function getChapterCount(app, book) {
+    for (const testament in app.bibleBooks) {
+        if (app.bibleBooks[testament][book]) {
+            return app.bibleBooks[testament][book];
+        }
+    }
+    return 0;
+}
+
+/**
+ * Returns 'Old Testament', 'New Testament', or null.
+ * @param {object} app
+ * @param {string} book
+ * @returns {string|null}
+ */
+export function getTestament(app, book) {
+    if (app.bibleBooks['Old Testament'][book]) return 'Old Testament';
+    if (app.bibleBooks['New Testament'][book]) return 'New Testament';
+    return null;
+}
+
+/**
+ * Returns the display name for a book (e.g. 'Psalm' → 'Psalms').
+ * @param {object} app
+ * @param {string} book
+ * @returns {string}
+ */
+export function getDisplayName(app, book) {
+    return app.bookDisplayNames[book] || book;
+}

--- a/events.js
+++ b/events.js
@@ -1,0 +1,101 @@
+// events.js
+// Wires all DOM event listeners to BibleApp instance methods.
+// New feature bindings go here — app.js does not need to change.
+
+import { toggleTheme, changeColorTheme } from './ui.js';
+import { attachDragToResize } from './modals.js';
+
+/**
+ * @param {object} app - BibleApp instance
+ */
+export function attachEventListeners(app) {
+    // ── Search ───────────────────────────────────────────────────
+    app.searchToggleBtn?.addEventListener('click', () => app.toggleSearch());
+    app.closeSearchBtn?.addEventListener('click',  () => app.closeSearch());
+    app.searchInput?.addEventListener('input',     (e) => app.handleSearch(e.target.value));
+    app.searchInput?.addEventListener('keydown',   (e) => app.handleSearchKeydown(e));
+
+    // ── Navigation ──────────────────────────────────────────────
+    app.prevChapterBtn?.addEventListener('click',  () => app.navigateChapter(-1));
+    app.nextChapterBtn?.addEventListener('click',  () => app.navigateChapter(1));
+    app.bookSelector?.addEventListener('click',    () => app.openBookModal());
+    app.chapterSelector?.addEventListener('click', () => app.openChapterModal());
+    app.verseSelector?.addEventListener('click',   () => app.openVerseModal());
+
+    // ── Modals: late-cached elements ─────────────────────────────────
+    app.referencesModal        = document.getElementById('referencesModal');
+    app.closeReferencesModal   = document.getElementById('closeReferencesModal');
+    app.footnotesSection       = document.getElementById('footnotesSection');
+    app.footnotesContent       = document.getElementById('footnotesContent');
+    app.crossReferencesSection = document.getElementById('crossReferencesSection');
+    app.crossReferencesContent = document.getElementById('crossReferencesContent');
+
+    // Backdrop-click closes any modal
+    [
+        app.bookModal, app.chapterModal, app.verseModal,
+        app.settingsModal, app.helpModal, app.loginModal,
+        app.signupModal, app.userMenuModal, app.referencesModal,
+    ].forEach((modal) => {
+        if (!modal) return;
+        modal.addEventListener('click', (e) => { if (e.target === modal) app.closeModal(modal); });
+    });
+
+    app.helpBtn?.addEventListener('click',            () => app.openModal(app.helpModal));
+    app.settingsBtn?.addEventListener('click',        () => app.openModal(app.settingsModal));
+    app.closeVerseModal?.addEventListener('click',    () => app.closeModal(app.verseModal));
+    app.closeBookModal?.addEventListener('click',     () => app.closeModal(app.bookModal));
+    app.closeChapterModal?.addEventListener('click',  () => app.closeModal(app.chapterModal));
+    app.closeHelpModal?.addEventListener('click',     () => app.closeModal(app.helpModal));
+    app.closeSettingsModal?.addEventListener('click', () => app.closeModal(app.settingsModal));
+    app.closeReferencesModal?.addEventListener('click', () => app.closeModal(app.referencesModal));
+
+    attachDragToResize(app);
+
+    // ── Settings toggles ────────────────────────────────────────────
+    app.verseNumbersToggle?.addEventListener('change', () => app.toggleSetting('showVerseNumbers'));
+    app.headingsToggle?.addEventListener('change',     () => app.toggleSetting('showHeadings'));
+    app.footnotesToggle?.addEventListener('change',    () => app.toggleSetting('showFootnotes'));
+
+    app.crossReferencesToggle = document.getElementById('crossReferencesToggle');
+    app.crossReferencesToggle?.addEventListener('change', () => app.toggleSetting('showCrossReferences'));
+
+    app.verseByVerseToggle?.addEventListener('change', () => app.toggleVerseByVerse());
+    app.fontSizeSlider?.addEventListener('input',  (e) => app.updateFontSize(e.target.value));
+    app.translationSelector?.addEventListener('change', async (e) => app.changeTranslation(e.target.value));
+
+    // ── Theme ────────────────────────────────────────────────────
+    app.themeToggleBtn?.addEventListener('click', () => toggleTheme(app));
+    document.getElementById('themeSelector')?.addEventListener('change',   (e) => changeColorTheme(app, e.target.value));
+    document.getElementById('lightModeToggle')?.addEventListener('change', () => toggleTheme(app));
+
+    // ── Auth ─────────────────────────────────────────────────────
+    app.userBtn?.addEventListener('click', () => app.handleUserButtonClick());
+
+    document.getElementById('showSignupLink')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        app.closeModal(app.loginModal);
+        app.openModal(app.signupModal);
+    });
+    document.getElementById('showLoginLink')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        app.closeModal(app.signupModal);
+        app.openModal(app.loginModal);
+    });
+    document.getElementById('loginForm')?.addEventListener('submit',  (e) => { e.preventDefault(); app.handleLogin(); });
+    document.getElementById('signupForm')?.addEventListener('submit', (e) => { e.preventDefault(); app.handleSignup(); });
+    document.getElementById('logoutBtn')?.addEventListener('click',   () => app.handleLogout());
+
+    app.closeLoginModal?.addEventListener('click',    () => app.closeModal(app.loginModal));
+    app.closeSignupModal?.addEventListener('click',   () => app.closeModal(app.signupModal));
+    app.closeUserMenuModal?.addEventListener('click', () => app.closeModal(app.userMenuModal));
+
+    // ── Scroll (chrome hide/show + position save) ───────────────────
+    window.addEventListener('scroll', () => {
+        app.handleChromeScroll();
+        clearTimeout(app.scrollTimeout);
+        app.scrollTimeout = setTimeout(() => app.saveReadingPosition(), 500);
+    }, { passive: true });
+
+    // ── Keyboard ────────────────────────────────────────────────
+    document.addEventListener('keydown', (e) => app.handleKeyboardShortcuts(e));
+}

--- a/keyboard.js
+++ b/keyboard.js
@@ -1,0 +1,68 @@
+// keyboard.js
+// Global keyboard shortcut handler for BibleApp.
+
+/**
+ * @param {object} app - BibleApp instance
+ * @param {KeyboardEvent} e
+ */
+export function handleKeyboardShortcuts(app, e) {
+    // Search toggle
+    if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        app.toggleSearch();
+        return;
+    }
+
+    // Dismiss any open modal or search
+    if (e.key === 'Escape') {
+        [
+            app.bookModal, app.chapterModal, app.helpModal,
+            app.settingsModal, app.loginModal, app.signupModal,
+            app.userMenuModal, app.verseModal, app.referencesModal,
+        ].forEach((m) => { if (m?.classList.contains('active')) app.closeModal(m); });
+        if (app.searchContainer?.classList.contains('active')) app.closeSearch();
+        return;
+    }
+
+    // Navigation and reading shortcuts — only when no modal/search is open
+    const modalOpen  = !!document.querySelector('.modal.active');
+    const searchOpen = !!app.searchContainer?.classList.contains('active');
+    if (modalOpen || searchOpen) return;
+
+    switch (e.key) {
+        case 'ArrowLeft':
+        case 'h':
+            e.preventDefault();
+            app.navigateChapter(-1);
+            break;
+        case 'ArrowRight':
+        case 'l':
+            e.preventDefault();
+            app.navigateChapter(1);
+            break;
+        case 'ArrowUp':
+        case 'k':
+            e.preventDefault();
+            app.navigateToPreviousVerse();
+            break;
+        case 'ArrowDown':
+        case 'j':
+            e.preventDefault();
+            app.navigateToNextVerse();
+            break;
+        case 'v':
+            e.preventDefault();
+            if (app.verseByVerseToggle) {
+                app.verseByVerseToggle.checked = !app.verseByVerseToggle.checked;
+                app.toggleVerseByVerse();
+            }
+            break;
+        case 's':
+            e.preventDefault();
+            if (app.headingsToggle) {
+                app.headingsToggle.checked = !app.headingsToggle.checked;
+                app.toggleSetting('showHeadings');
+            }
+            break;
+    }
+}

--- a/modals.js
+++ b/modals.js
@@ -1,0 +1,210 @@
+// modals.js
+// Modal open/close, population, and drag-to-resize for BibleApp.
+
+// ─── Open / close ─────────────────────────────────────────────────────────────
+
+export function openModal(app, modal) {
+    if (!modal) return;
+    modal.classList.add('active');
+    document.body.style.overflow = 'hidden';
+}
+
+export function closeModal(app, modal) {
+    if (!modal) return;
+    if (modal === app.settingsModal || modal === app.referencesModal) {
+        const content = modal.querySelector('.modal-content');
+        content.style.animation = 'slideDownToBottom 250ms ease';
+        setTimeout(() => {
+            modal.classList.remove('active');
+            document.body.style.overflow = '';
+            content.style.animation = '';
+        }, 250);
+    } else {
+        modal.classList.remove('active');
+        document.body.style.overflow = '';
+    }
+}
+
+// ─── Book modal ───────────────────────────────────────────────────────────────
+
+export function openBookModal(app) {
+    populateBookModal(app);
+    openModal(app, app.bookModal);
+}
+
+export function populateBookModal(app) {
+    const createBookButton = (book) => {
+        const btn = document.createElement('button');
+        btn.className = 'book-item';
+        btn.textContent = app.bookAbbreviations[book] || book;
+        btn.addEventListener('click', () => {
+            app.state.selectedVerse = null;
+            app.loadPassage(book, 1);
+            app.closeModal(app.bookModal);
+        });
+        return btn;
+    };
+
+    app.oldTestamentBooks.innerHTML = '';
+    Object.keys(app.bibleBooks['Old Testament']).forEach((book) => {
+        app.oldTestamentBooks.appendChild(createBookButton(book));
+    });
+
+    app.newTestamentBooks.innerHTML = '';
+    Object.keys(app.bibleBooks['New Testament']).forEach((book) => {
+        app.newTestamentBooks.appendChild(createBookButton(book));
+    });
+}
+
+// ─── Chapter modal ────────────────────────────────────────────────────────────
+
+export function openChapterModal(app) {
+    populateChapterModal(app);
+    openModal(app, app.chapterModal);
+}
+
+export function populateChapterModal(app) {
+    app.chapterModalBook.textContent = app.getDisplayName(app.state.currentBook);
+    app.chapterGrid.innerHTML = '';
+
+    const chapterCount = app.getChapterCount(app.state.currentBook);
+
+    for (let i = 1; i <= chapterCount; i++) {
+        const btn = document.createElement('button');
+        btn.className = 'chapter-item';
+        btn.textContent = i;
+        btn.addEventListener('click', () => {
+            app.state.selectedVerse = null;
+            app.loadPassage(app.state.currentBook, i);
+            app.closeModal(app.chapterModal);
+        });
+        app.chapterGrid.appendChild(btn);
+    }
+}
+
+// ─── Verse modal ──────────────────────────────────────────────────────────────
+
+export function openVerseModal(app) {
+    populateVerseModal(app);
+    openModal(app, app.verseModal);
+}
+
+export function populateVerseModal(app) {
+    const book = app.state.currentBook;
+    const displayBook = book === 'Psalm'
+        ? `Psalm ${app.state.currentChapter}`
+        : `${app.getDisplayName(book)} ${app.state.currentChapter}`;
+    app.verseModalBook.textContent = displayBook;
+    app.verseGrid.innerHTML = '';
+
+    const verseCount = getCurrentVerseCount(app);
+
+    if (verseCount === 0) {
+        app.verseGrid.innerHTML = '<p style="text-align: center; padding: 20px; color: var(--text-secondary);">No verses found in current passage</p>';
+        return;
+    }
+
+    for (let i = 1; i <= verseCount; i++) {
+        const btn = document.createElement('button');
+        btn.className = 'chapter-item';
+        btn.textContent = i;
+        btn.addEventListener('click', () => {
+            app.scrollToVerse(i);
+            app.closeModal(app.verseModal);
+        });
+        app.verseGrid.appendChild(btn);
+    }
+}
+
+export function getCurrentVerseCount(app) {
+    return app.passageText.querySelectorAll('.verse-num').length;
+}
+
+// ─── Drag-to-resize ───────────────────────────────────────────────────────────
+
+/**
+ * Attaches touch + mouse drag-to-resize handlers to a bottom-sheet modal.
+ * @param {object} app        - BibleApp instance
+ * @param {Element} modal     - the modal root element
+ * @param {boolean} [dismissOnDrag=true] - close modal when dragged down far enough
+ */
+function attachDragHandlers(app, modal, dismissOnDrag = true) {
+    const content = modal.querySelector('.modal-content');
+    const header  = modal.querySelector('.modal-header');
+    const body    = modal.querySelector('.modal-body');
+
+    if (!content || !header) return;
+
+    // ── touch ──
+    let isTouchDragging = false;
+    let touchStartY = 0;
+    let touchStartHeight = 0;
+    let touchStartScrollTop = 0;
+
+    header.addEventListener('touchstart', (e) => {
+        if (!header.contains(e.target)) return;
+        isTouchDragging = true;
+        touchStartY = e.touches[0].clientY;
+        touchStartHeight = content.offsetHeight;
+        touchStartScrollTop = body?.scrollTop ?? 0;
+        content.classList.add('dragging');
+    }, { passive: false });
+
+    document.addEventListener('touchmove', (e) => {
+        if (!isTouchDragging) return;
+        const deltaY = touchStartY - e.touches[0].clientY;
+        const newH = Math.max(200, Math.min(window.innerHeight * 0.9, touchStartHeight + deltaY));
+        content.style.height = `${newH}px`;
+        e.preventDefault();
+    }, { passive: false });
+
+    document.addEventListener('touchend', (e) => {
+        if (!isTouchDragging) return;
+        isTouchDragging = false;
+        content.classList.remove('dragging');
+        const totalDrag = e.changedTouches[0].clientY - touchStartY;
+        if (dismissOnDrag && totalDrag > 150 && touchStartScrollTop === 0) {
+            app.closeModal(modal);
+            setTimeout(() => { content.style.height = '50vh'; }, 300);
+        }
+    }, { passive: true });
+
+    // ── mouse ──
+    let isMouseDragging = false;
+    let mouseStartY = 0;
+    let mouseStartHeight = 0;
+
+    header.addEventListener('mousedown', (e) => {
+        if (e.target.closest('.close-btn')) return;
+        isMouseDragging = true;
+        mouseStartY = e.clientY;
+        mouseStartHeight = content.offsetHeight;
+        content.classList.add('dragging');
+        e.preventDefault();
+    });
+
+    document.addEventListener('mousemove', (e) => {
+        if (!isMouseDragging) return;
+        const newH = Math.max(200, Math.min(window.innerHeight * 0.9, mouseStartHeight + (mouseStartY - e.clientY)));
+        content.style.height = `${newH}px`;
+    });
+
+    document.addEventListener('mouseup', (e) => {
+        if (!isMouseDragging) return;
+        isMouseDragging = false;
+        content.classList.remove('dragging');
+        if (dismissOnDrag && e.clientY - mouseStartY > 150) {
+            app.closeModal(modal);
+            setTimeout(() => { content.style.height = '50vh'; }, 300);
+        }
+    });
+}
+
+/**
+ * Call once from attachEventListeners to wire drag-to-resize on all
+ * bottom-sheet modals (settings + references).
+ */
+export function attachDragToResize(app) {
+    if (app.settingsModal)   attachDragHandlers(app, app.settingsModal);
+    if (app.referencesModal) attachDragHandlers(app, app.referencesModal);
+}

--- a/navigation.js
+++ b/navigation.js
@@ -1,0 +1,71 @@
+// navigation.js
+// Chapter and verse navigation helpers.
+// All functions accept an `app` instance as their first argument.
+
+/**
+ * Updates the book/chapter span text and enables/disables the prev/next
+ * chapter buttons based on the current position in the canon.
+ * @param {object} app
+ */
+export function updateNavigationState(app) {
+    const book = app.state.currentBook;
+    const abbr = app.bookAbbreviations[book] || book;
+    app.currentBookSpan.textContent = abbr;
+    app.currentChapterSpan.textContent = app.state.currentChapter;
+
+    const books = app.getAllBooks();
+    const currentBookIndex = books.indexOf(book);
+    const isFirstChapter = app.state.currentChapter === 1;
+    const isLastChapter = app.state.currentChapter === app.getChapterCount(book);
+
+    if (app.prevChapterBtn) app.prevChapterBtn.disabled = currentBookIndex === 0 && isFirstChapter;
+    if (app.nextChapterBtn) app.nextChapterBtn.disabled = currentBookIndex === books.length - 1 && isLastChapter;
+}
+
+/**
+ * Scrolls to the next verse in the current chapter, or advances to the
+ * next chapter if already on the last verse.
+ * @param {object} app
+ */
+export function navigateToNextVerse(app) {
+    const currentVerse = app.state.selectedVerse || 1;
+    const maxVerse = app.getCurrentVerseCount();
+
+    if (currentVerse < maxVerse) {
+        app.scrollToVerse(currentVerse + 1);
+    } else {
+        app.navigateChapter(1);
+    }
+}
+
+/**
+ * Scrolls to the previous verse in the current chapter, or goes back to
+ * the last verse of the previous chapter (or previous book) if already
+ * on verse 1.
+ * @param {object} app
+ */
+export function navigateToPreviousVerse(app) {
+    const currentVerse = app.state.selectedVerse || 1;
+
+    if (currentVerse > 1) {
+        app.scrollToVerse(currentVerse - 1);
+        return;
+    }
+
+    const books = app.getAllBooks();
+    const currentBookIndex = books.indexOf(app.state.currentBook);
+    const isFirstChapter = app.state.currentChapter === 1;
+
+    if (currentBookIndex === 0 && isFirstChapter) return;
+
+    let newChapter = app.state.currentChapter - 1;
+    let newBook = app.state.currentBook;
+
+    if (newChapter < 1) {
+        newBook = books[currentBookIndex - 1];
+        newChapter = app.getChapterCount(newBook);
+    }
+
+    app.state.selectedVerse = null;
+    app.loadPassage(newBook, newChapter);
+}

--- a/search.js
+++ b/search.js
@@ -1,0 +1,393 @@
+// search.js
+// All search-related logic for BibleApp.
+// Every function accepts an `app` instance as its first argument.
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
+
+export function escapeRegExp(str) {
+    return String(str).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function stripHTML(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+}
+
+export function highlightSearchTerm(text, term) {
+    if (text == null) return '';
+    const safeText = String(text);
+    const rawTerm = term == null ? '' : String(term).trim();
+    if (!rawTerm) return safeText;
+    try {
+        const regex = new RegExp(escapeRegExp(rawTerm), 'gi');
+        return safeText.replace(regex, (match) => `<strong>${match}</strong>`);
+    } catch (err) {
+        console.warn('highlightSearchTerm failed', err);
+        return safeText;
+    }
+}
+
+// ─── Reference parsing ────────────────────────────────────────────────────────
+
+export function parseReference(reference) {
+    const cleaned = String(reference || '').trim();
+    const match = cleaned.match(/^((?:\d\s+)?[A-Za-z][A-Za-z ]*?)\s+(\d+)(?::(\d+))?$/);
+    if (!match) return null;
+
+    const book = match[1].trim();
+    const chapter = parseInt(match[2], 10);
+    const verse = match[3] ? parseInt(match[3], 10) : null;
+
+    if (!book || !Number.isFinite(chapter)) return null;
+    if (verse !== null && !Number.isFinite(verse)) return null;
+
+    return { book, chapter, verse };
+}
+
+export function isPassageReference(query) {
+    const patterns = [
+        /^[1-3]?\s*[a-z]+\s+\d+/i,
+        /^[1-3]?\s*[a-z]+\s+\d+:\d+/i,
+    ];
+    return patterns.some((p) => p.test(query.trim()));
+}
+
+export async function loadPassageFromReference(app, reference) {
+    const parsed = parseReference(reference);
+    if (!parsed) return;
+    const { book, chapter, verse } = parsed;
+    app.state.selectedVerse = verse || null;
+    await app.loadPassage(book, chapter);
+    if (verse) app.scrollToVerse(verse);
+}
+
+// ─── UI state ─────────────────────────────────────────────────────────────────
+
+export function toggleSearch(app) {
+    app.searchContainer.classList.toggle('active');
+    if (app.searchContainer.classList.contains('active')) {
+        app.searchInput.focus();
+    } else {
+        app.searchInput.value = '';
+        app.searchResults.innerHTML = '';
+        app.searchSelectedIndex = -1;
+        app.searchResultItems = [];
+    }
+}
+
+export function closeSearch(app) {
+    app.searchContainer.classList.remove('active');
+    app.searchInput.value = '';
+    app.searchResults.innerHTML = '';
+    app.searchSelectedIndex = -1;
+    app.searchResultItems = [];
+}
+
+// ─── Input handling ───────────────────────────────────────────────────────────
+
+export function handleSearch(app, query) {
+    clearTimeout(app.searchTimeout);
+    app.searchLastQuery = query;
+    app.currentSearchResults = [];
+
+    if (!query.trim()) {
+        app.searchResults.innerHTML = '';
+        app.searchSelectedIndex = -1;
+        app.searchResultItems = null;
+        return;
+    }
+
+    app.searchTimeout = setTimeout(async () => {
+        if (isPassageReference(query)) {
+            await handlePassageReference(app, query);
+        } else {
+            await performKeywordSearch(app, query);
+        }
+    }, 300);
+}
+
+export function handleSearchKeydown(app, e) {
+    if (e.key === 'Escape') {
+        e.preventDefault();
+        closeSearch(app);
+        return;
+    }
+
+    if (!app.searchResultItems || app.searchResultItems.length === 0) return;
+
+    if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSearchSelectedIndex(app, Math.min(app.searchSelectedIndex + 1, app.searchResultItems.length - 1), true);
+        return;
+    }
+
+    if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSearchSelectedIndex(app, Math.max(app.searchSelectedIndex - 1, 0), true);
+        return;
+    }
+
+    if (e.key === 'Enter') {
+        e.preventDefault();
+        activateSelectedSearchResult(app);
+    }
+}
+
+// ─── Result list selection ────────────────────────────────────────────────────
+
+export function refreshSearchResultItems(app, autoSelectFirst = false) {
+    app.searchResultItems = Array.from(
+        app.searchResults.querySelectorAll('.search-result-item')
+    );
+
+    if (!app.searchResultItems.length) {
+        app.searchSelectedIndex = -1;
+        return;
+    }
+
+    if (autoSelectFirst) {
+        setSearchSelectedIndex(app, 0, false);
+    } else {
+        if (app.searchSelectedIndex < 0 || app.searchSelectedIndex >= app.searchResultItems.length) {
+            app.searchSelectedIndex = -1;
+        } else {
+            setSearchSelectedIndex(app, app.searchSelectedIndex, false);
+        }
+    }
+}
+
+export function setSearchSelectedIndex(app, index, scrollIntoView = false) {
+    if (!app.searchResultItems || app.searchResultItems.length === 0) {
+        app.searchSelectedIndex = -1;
+        return;
+    }
+
+    const clamped = Math.max(0, Math.min(index, app.searchResultItems.length - 1));
+    app.searchSelectedIndex = clamped;
+
+    app.searchResultItems.forEach((el, i) => {
+        el.classList.toggle('selected', i === clamped);
+    });
+
+    if (scrollIntoView) {
+        app.searchResultItems[clamped]?.scrollIntoView({ block: 'nearest' });
+    }
+}
+
+export function activateSelectedSearchResult(app) {
+    if (!app.searchResultItems || app.searchSelectedIndex < 0 || app.searchSelectedIndex >= app.searchResultItems.length) return;
+    app.searchResultItems[app.searchSelectedIndex]?.click();
+}
+
+// ─── API calls ────────────────────────────────────────────────────────────────
+
+export async function handlePassageReference(app, reference) {
+    const data = await app.bibleApi.fetchPassage(reference);
+
+    if (data && data.passages && data.passages.length > 0) {
+        const safeCanonical = String(data.canonical || '').replace(/"/g, '&quot;');
+        const preview = stripHTML(data.passages[0]).substring(0, 200);
+
+        app.searchResults.innerHTML =
+            '<div class="search-result-item" data-reference="' + safeCanonical + '">' +
+            '<div class="search-result-reference">' + safeCanonical + '</div>' +
+            '<div class="search-result-content">' + preview + '...</div>' +
+            '</div>';
+
+        const item = app.searchResults.querySelector('.search-result-item');
+        if (item) {
+            item.addEventListener('click', async () => {
+                await loadPassageFromReference(app, item.dataset.reference);
+                closeSearch(app);
+            });
+        }
+
+        refreshSearchResultItems(app, true);
+    } else {
+        app.searchResults.innerHTML = '<div class="search-no-results">No passage found</div>';
+        refreshSearchResultItems(app, false);
+    }
+}
+
+export async function fetchAllSearchResults(app, query, onBatch) {
+    app.currentSearchResults = [];
+    await app.bibleApi.searchPassages(query, (batchResults) => {
+        app.currentSearchResults.push(...batchResults);
+        if (typeof onBatch === 'function') onBatch(app.currentSearchResults.slice());
+    });
+    return app.currentSearchResults;
+}
+
+// ─── Grouping & display ───────────────────────────────────────────────────────
+
+export function groupSearchResultsByCanon(app, results) {
+    if (!Array.isArray(results)) return [];
+
+    const otBooks = Object.keys(app.bibleBooks['Old Testament']);
+    const ntBooks = Object.keys(app.bibleBooks['New Testament']);
+    const otGroups = new Map();
+    const ntGroups = new Map();
+
+    for (const result of results) {
+        const parsed = parseReference(result.reference);
+        if (!parsed) continue;
+        const { book } = parsed;
+        const testament = app.getTestament?.(book);
+
+        if (testament === 'Old Testament') {
+            if (!otGroups.has(book)) otGroups.set(book, []);
+            otGroups.get(book).push(result);
+        } else if (testament === 'New Testament') {
+            if (!ntGroups.has(book)) ntGroups.set(book, []);
+            ntGroups.get(book).push(result);
+        }
+    }
+
+    const grouped = [];
+
+    if (otGroups.size) {
+        grouped.push({
+            heading: 'Old Testament',
+            books: otBooks.filter((b) => otGroups.has(b)).map((book) => ({ book, results: otGroups.get(book) })),
+        });
+    }
+
+    if (ntGroups.size) {
+        grouped.push({
+            heading: 'New Testament',
+            books: ntBooks.filter((b) => ntGroups.has(b)).map((book) => ({ book, results: ntGroups.get(book) })),
+        });
+    }
+
+    return grouped;
+}
+
+export async function performKeywordSearch(app, query) {
+    app.searchResults.innerHTML = '<div class="loading" style="min-height: 100px">Searching...</div>';
+    app.searchSelectedIndex = -1;
+    app.searchResultItems = [];
+
+    app.searchExpandedTestaments?.clear();
+    app.searchExpandedBooks?.clear();
+
+    await fetchAllSearchResults(app, query, (accumulatedResults) => {
+        if (accumulatedResults.length > 0) {
+            displaySearchResults(app, accumulatedResults, query);
+        }
+    });
+
+    if (app.currentSearchResults.length > 0) {
+        displaySearchResults(app, app.currentSearchResults, query);
+    } else {
+        app.searchResults.innerHTML = '<div class="search-no-results">No results found</div>';
+        refreshSearchResultItems(app, false);
+    }
+}
+
+export function displaySearchResults(app, results, query) {
+    const groups = groupSearchResultsByCanon(app, results);
+
+    if (!groups.length) {
+        app.searchResults.innerHTML = '<div class="search-no-results">No results found</div>';
+        refreshSearchResultItems(app, false);
+        return;
+    }
+
+    if (app.searchExpandedTestaments.size === 0 && app.searchExpandedBooks.size === 0) {
+        const firstGroup = groups[0];
+        if (firstGroup) {
+            app.searchExpandedTestaments.add(firstGroup.heading);
+            const firstBook = firstGroup.books && firstGroup.books[0];
+            if (firstBook) app.searchExpandedBooks.add(firstBook.book);
+        }
+    }
+
+    const esc = (str) =>
+        String(str || '')
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+    const parts = [];
+
+    for (const group of groups) {
+        const testName = group.heading;
+        const testamentExpanded = app.searchExpandedTestaments.has(testName);
+
+        parts.push(`
+      <div class="search-group-heading" data-testament="${esc(testName)}">
+        <span class="search-group-title">${esc(testName)}</span>
+        <span class="search-group-chevron ${testamentExpanded ? 'expanded' : ''}">&#9662;</span>
+      </div>
+    `);
+
+        if (!testamentExpanded) continue;
+
+        for (const bookBlock of group.books) {
+            const bookName = bookBlock.book;
+            const bookExpanded = app.searchExpandedBooks.has(bookName);
+
+            parts.push(`
+        <div class="search-book-heading" data-book="${esc(bookName)}">
+          <span class="search-book-title">${esc(app.getDisplayName(bookName))}</span>
+          <span class="search-book-chevron ${bookExpanded ? 'expanded' : ''}">&#9662;</span>
+        </div>
+      `);
+
+            if (!bookExpanded) continue;
+
+            for (const result of bookBlock.results) {
+                let highlighted = result.content;
+                try {
+                    highlighted = highlightSearchTerm(result.content, query);
+                } catch (err) {
+                    console.warn('highlight failed', err);
+                }
+
+                parts.push(`
+          <div class="search-result-item" data-reference="${esc(result.reference)}">
+            <div class="search-result-reference">${esc(result.reference)}</div>
+            <div class="search-result-content">${highlighted}</div>
+          </div>
+        `);
+            }
+        }
+    }
+
+    app.searchResults.innerHTML = parts.join('');
+
+    app.searchResults.querySelectorAll('.search-group-heading').forEach((el) => {
+        el.addEventListener('click', () => {
+            const testament = el.getAttribute('data-testament');
+            if (!testament) return;
+            if (app.searchExpandedTestaments.has(testament)) {
+                app.searchExpandedTestaments.delete(testament);
+            } else {
+                app.searchExpandedTestaments.add(testament);
+            }
+            displaySearchResults(app, results, query);
+        });
+    });
+
+    app.searchResults.querySelectorAll('.search-book-heading').forEach((el) => {
+        el.addEventListener('click', () => {
+            const book = el.getAttribute('data-book');
+            if (!book) return;
+            if (app.searchExpandedBooks.has(book)) {
+                app.searchExpandedBooks.delete(book);
+            } else {
+                app.searchExpandedBooks.add(book);
+            }
+            displaySearchResults(app, results, query);
+        });
+    });
+
+    app.searchResults.querySelectorAll('.search-result-item').forEach((item) => {
+        item.addEventListener('click', async () => {
+            await loadPassageFromReference(app, item.dataset.reference);
+            closeSearch(app);
+        });
+    });
+
+    refreshSearchResultItems(app, true);
+}

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,151 @@
+// settings.js
+// Reading preferences: load from storage, apply to DOM, persist to Firebase or localStorage.
+
+import { changeColorTheme, updateThemeIcon } from './ui.js';
+
+const DEFAULTS = {
+    fontSize:            18,
+    showVerseNumbers:    true,
+    showHeadings:        true,
+    showFootnotes:       false,
+    showCrossReferences: false,
+    verseByVerse:        false,
+    lightMode:           false,
+    colorTheme:          'dracula',
+    translation:         'ESV',
+};
+
+function readBool(key, defaultValue) {
+    try {
+        const v = localStorage.getItem(key);
+        if (v === null) return defaultValue;
+        if (v === 'true') return true;
+        if (v === 'false') return false;
+        return defaultValue;
+    } catch { return defaultValue; }
+}
+
+export function loadLocalSettings(app) {
+    try { app.state.fontSize = parseInt(localStorage.getItem('fontSize') || String(DEFAULTS.fontSize), 10); }
+    catch (_) { app.state.fontSize = DEFAULTS.fontSize; }
+
+    app.state.showVerseNumbers    = readBool('showVerseNumbers',    DEFAULTS.showVerseNumbers);
+    app.state.showHeadings        = readBool('showHeadings',        DEFAULTS.showHeadings);
+    app.state.showFootnotes       = readBool('showFootnotes',       DEFAULTS.showFootnotes);
+    app.state.showCrossReferences = readBool('showCrossReferences', DEFAULTS.showCrossReferences);
+    app.state.verseByVerse        = readBool('verseByVerse',        DEFAULTS.verseByVerse);
+    app.state.lightMode           = readBool('lightMode',           DEFAULTS.lightMode);
+
+    try { app.state.colorTheme = localStorage.getItem('colorTheme') || DEFAULTS.colorTheme; }
+    catch (_) { app.state.colorTheme = DEFAULTS.colorTheme; }
+
+    try { app.state.translation = app._normalizeTranslation(localStorage.getItem('translation') || DEFAULTS.translation); }
+    catch (_) { app.state.translation = DEFAULTS.translation; }
+}
+
+export function applySettings(app) {
+    const themeSelector = document.getElementById('themeSelector');
+    if (themeSelector && app.state.colorTheme) themeSelector.value = app.state.colorTheme;
+    changeColorTheme(app, app.state.colorTheme || DEFAULTS.colorTheme);
+
+    if (app.translationSelector && app.state.translation) {
+        app.translationSelector.value = app.state.translation;
+    }
+    app.bibleApi.setTranslation(app.state.translation || DEFAULTS.translation);
+
+    document.body.classList.toggle('light-mode', !!app.state.lightMode);
+    const lightModeToggle = document.getElementById('lightModeToggle');
+    if (lightModeToggle) lightModeToggle.checked = !!app.state.lightMode;
+    updateThemeIcon(app.state.lightMode);
+
+    document.body.classList.toggle('hide-verse-numbers', !app.state.showVerseNumbers);
+    if (app.verseNumbersToggle)   app.verseNumbersToggle.checked   = !!app.state.showVerseNumbers;
+    if (app.headingsToggle)       app.headingsToggle.checked       = !!app.state.showHeadings;
+    if (app.footnotesToggle)      app.footnotesToggle.checked      = !!app.state.showFootnotes;
+    if (app.crossReferencesToggle) app.crossReferencesToggle.checked = !!app.state.showCrossReferences;
+
+    if (app.passageText) app.passageText.classList.toggle('verse-by-verse', !!app.state.verseByVerse);
+    if (app.verseByVerseToggle) app.verseByVerseToggle.checked = !!app.state.verseByVerse;
+
+    const fontSize = app.state.fontSize || DEFAULTS.fontSize;
+    if (app.fontSizeSlider) app.fontSizeSlider.value = fontSize;
+    if (app.fontSizeValue)  app.fontSizeValue.textContent = `${fontSize}px`;
+    if (app.passageText)    app.passageText.style.fontSize = `${fontSize}px`;
+
+    updateCopyright(app);
+}
+
+const TOGGLE_MAP = {
+    showVerseNumbers:    'verseNumbersToggle',
+    showHeadings:        'headingsToggle',
+    showFootnotes:       'footnotesToggle',
+    showCrossReferences: 'crossReferencesToggle',
+};
+
+export async function toggleSetting(app, setting) {
+    const el = app[TOGGLE_MAP[setting]];
+    if (!el) return;
+    app.state[setting] = el.checked;
+
+    if (app.currentUser) {
+        await app.database
+            .ref(`users/${app.currentUser.uid}/settings/${setting}`)
+            .set(el.checked);
+    } else {
+        try { localStorage.setItem(setting, String(el.checked)); } catch (_) {}
+    }
+
+    if (setting === 'showHeadings') {
+        await app.loadPassage(app.state.currentBook, app.state.currentChapter);
+        return;
+    }
+
+    applySettings(app);
+}
+
+export async function toggleVerseByVerse(app) {
+    app.state.verseByVerse = app.verseByVerseToggle.checked;
+    if (app.currentUser) {
+        await app.database
+            .ref(`users/${app.currentUser.uid}/settings/verseByVerse`)
+            .set(app.state.verseByVerse);
+    } else {
+        try { localStorage.setItem('verseByVerse', String(app.state.verseByVerse)); } catch (_) {}
+    }
+    app.passageText.classList.toggle('verse-by-verse', app.state.verseByVerse);
+}
+
+export async function updateFontSize(app, size) {
+    app.state.fontSize = parseInt(size, 10);
+    app.fontSizeValue.textContent = `${size}px`;
+    app.passageText.style.fontSize = `${size}px`;
+    if (app.currentUser) {
+        await app.database
+            .ref(`users/${app.currentUser.uid}/settings/fontSize`)
+            .set(parseInt(size, 10));
+    } else {
+        try { localStorage.setItem('fontSize', size); } catch (_) {}
+    }
+}
+
+export async function changeTranslation(app, translation) {
+    app.state.translation = translation;
+    app.bibleApi.setTranslation(translation);
+
+    if (app.currentUser) {
+        await app.database
+            .ref(`users/${app.currentUser.uid}/settings/translation`)
+            .set(translation);
+    } else {
+        try { localStorage.setItem('translation', translation); } catch (_) {}
+    }
+
+    updateCopyright(app);
+    await app.loadPassage(app.state.currentBook, app.state.currentChapter);
+}
+
+export function updateCopyright(app) {
+    if (app.copyright) {
+        app.copyright.textContent = app._copyrightMap[app.state.translation] || '';
+    }
+}


### PR DESCRIPTION
Splits the monolithic `app.js` into single-responsibility modules so that future feature additions touch only the files relevant to that feature.

## Modules extracted

| Module | Responsibility |
|---|---|
| `settings.js` | Load, apply, and persist user preferences |
| `keyboard.js` | Global keyboard shortcut handler |
| `events.js` | All DOM event listener wiring |

## Result

`app.js` is now a thin orchestrator: constructor, `init`, `loadPassage`, SW registration, and one-liner delegation methods. It should not grow further unless the app lifecycle or passage loading changes.

## README

Added an **Architecture** section with a feature-routing table so the module boundaries are documented.