### PR TITLE
fix: nav button focus persistence & translation badge styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ import {
     openBookModal, populateBookModal,
     openChapterModal, populateChapterModal,
     openVerseModal, populateVerseModal,
+    openTranslationModal, populateTranslationModal,
     getCurrentVerseCount,
 } from './modals.js';
 import {
@@ -284,6 +285,7 @@ class BibleApp {
         this.database = window.firebaseDatabase;
         this.currentUser = null;
         this._copyrightMap = {};
+        this._translationRegistry = [];
         this._normalizeTranslation = normalizeTranslation;
 
         // Debug instrumentation — REMOVE BEFORE MERGING TO MAIN.
@@ -568,6 +570,8 @@ class BibleApp {
 
     async _loadTranslationRegistry() {
         const translations = await loadTranslationIndex();
+        // Save to instance so populateTranslationModal can read it.
+        this._translationRegistry = translations.map(t => ({ id: t.id, name: t.label }));
         const select = document.getElementById('translationSelector');
         if (select && translations.length > 0) {
             select.innerHTML = '';
@@ -686,17 +690,19 @@ class BibleApp {
     highlightSearchTerm(text, term)         { return highlightSearchTerm(text, term); }
     stripHTML(html)                         { return stripHTML(html); }
 
-    openModal(modal)       { openModal(this, modal); }
-    closeModal(modal)      { closeModal(this, modal); }
-    openBookModal()        { openBookModal(this); }
-    populateBookModal()    { populateBookModal(this); }
-    openChapterModal()     { openChapterModal(this); }
-    populateChapterModal() { populateChapterModal(this); }
-    openVerseModal()       { openVerseModal(this); }
-    populateVerseModal()   { populateVerseModal(this); }
-    getCurrentVerseCount() { return getCurrentVerseCount(this); }
-    scrollToVerse(n)       { scrollVerse(this, n); }
-    applyVerseGlow()       { glowVerse(this); }
+    openModal(modal)           { openModal(this, modal); }
+    closeModal(modal)          { closeModal(this, modal); }
+    openBookModal()            { openBookModal(this); }
+    populateBookModal()        { populateBookModal(this); }
+    openChapterModal()         { openChapterModal(this); }
+    populateChapterModal()     { populateChapterModal(this); }
+    openVerseModal()           { openVerseModal(this); }
+    populateVerseModal()       { populateVerseModal(this); }
+    openTranslationModal()     { openTranslationModal(this); }
+    populateTranslationModal() { populateTranslationModal(this); }
+    getCurrentVerseCount()     { return getCurrentVerseCount(this); }
+    scrollToVerse(n)           { scrollVerse(this, n); }
+    applyVerseGlow()           { glowVerse(this); }
 
     loadLocalSettings()          { loadLocalSettings(this); }
     applySettings()              { applySettings(this); }

--- a/events.js
+++ b/events.js
@@ -22,6 +22,9 @@ export function attachEventListeners(app) {
     app.chapterSelector?.addEventListener('click', () => app.openChapterModal());
     app.verseSelector?.addEventListener('click',   () => app.openVerseModal());
 
+    // ── Translation badge (nav) ──────────────────────────────────
+    app.translationSelectorBtn?.addEventListener('click', () => app.openTranslationModal());
+
     // ── Modals: late-cached elements ─────────────────────────────────
     app.referencesModal        = document.getElementById('referencesModal');
     app.closeReferencesModal   = document.getElementById('closeReferencesModal');
@@ -35,6 +38,7 @@ export function attachEventListeners(app) {
         app.bookModal, app.chapterModal, app.verseModal,
         app.settingsModal, app.helpModal, app.loginModal,
         app.signupModal, app.userMenuModal, app.referencesModal,
+        app.translationModal,
     ].forEach((modal) => {
         if (!modal) return;
         modal.addEventListener('click', (e) => { if (e.target === modal) app.closeModal(modal); });
@@ -48,6 +52,7 @@ export function attachEventListeners(app) {
     app.closeHelpModal?.addEventListener('click',     () => app.closeModal(app.helpModal));
     app.closeSettingsModal?.addEventListener('click', () => app.closeModal(app.settingsModal));
     app.closeReferencesModal?.addEventListener('click', () => app.closeModal(app.referencesModal));
+    app.closeTranslationModal?.addEventListener('click', () => app.closeModal(app.translationModal));
 
     attachDragToResize(app);
 
@@ -61,6 +66,7 @@ export function attachEventListeners(app) {
 
     app.verseByVerseToggle?.addEventListener('change', () => app.toggleVerseByVerse());
     app.fontSizeSlider?.addEventListener('input',  (e) => app.updateFontSize(e.target.value));
+    // Settings <select> still works as a secondary route
     app.translationSelector?.addEventListener('change', async (e) => app.changeTranslation(e.target.value));
 
     // ── Theme ────────────────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -108,6 +108,14 @@
 							<polyline points="6 9 12 15 18 9"></polyline>
 						</svg>
 					</button>
+
+					<button id="translationSelectorBtn" class="selector-btn selector-btn--translation" title="Change translation">
+						<span id="currentTranslation">KJV</span>
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+							stroke-width="2">
+							<polyline points="6 9 12 15 18 9"></polyline>
+						</svg>
+					</button>
 				</div>
 
 				<button id="nextChapter" class="nav-btn">
@@ -188,6 +196,19 @@
 			</div>
 			<div class="modal-body">
 				<div id="verseGrid" class="chapter-grid"></div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Translation picker modal -->
+	<div id="translationModal" class="modal">
+		<div class="modal-content modal-content--sm">
+			<div class="modal-header">
+				<h3>Translation</h3>
+				<button class="close-btn" id="closeTranslationModal">×</button>
+			</div>
+			<div class="modal-body">
+				<ul id="translationList" class="translation-modal-list"></ul>
 			</div>
 		</div>
 	</div>

--- a/modals.js
+++ b/modals.js
@@ -120,6 +120,55 @@ export function getCurrentVerseCount(app) {
     return app.passageText.querySelectorAll('.verse-num').length;
 }
 
+// ─── Translation modal ────────────────────────────────────────────────────────
+
+export function openTranslationModal(app) {
+    populateTranslationModal(app);
+    openModal(app, app.translationModal);
+}
+
+export function populateTranslationModal(app) {
+    if (!app.translationList) return;
+    app.translationList.innerHTML = '';
+
+    // _translationRegistry is populated by _loadTranslationRegistry() in app.js.
+    // Fall back gracefully if it hasn't loaded yet.
+    const registry = app._translationRegistry || [];
+
+    if (registry.length === 0) {
+        const msg = document.createElement('li');
+        msg.textContent = 'No translations available.';
+        msg.style.padding = 'var(--spacing-md)';
+        msg.style.color = 'var(--text-muted)';
+        app.translationList.appendChild(msg);
+        return;
+    }
+
+    for (const t of registry) {
+        const li = document.createElement('li');
+        li.className = 'translation-modal-item';
+        if (t.id === app.state.translation) li.classList.add('translation-modal-item--active');
+
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'translation-modal-item__name';
+        nameSpan.textContent = t.id;
+
+        const descSpan = document.createElement('span');
+        descSpan.className = 'translation-modal-item__desc';
+        descSpan.textContent = t.name || '';
+
+        li.appendChild(nameSpan);
+        li.appendChild(descSpan);
+
+        li.addEventListener('click', () => {
+            app.changeTranslation(t.id);
+            app.closeModal(app.translationModal);
+        });
+
+        app.translationList.appendChild(li);
+    }
+}
+
 // ─── Drag-to-resize ───────────────────────────────────────────────────────────
 
 /**

--- a/settings.js
+++ b/settings.js
@@ -70,6 +70,10 @@ export function applySettings(app) {
     if (app.translationSelector && app.state.translation) {
         app.translationSelector.value = app.state.translation;
     }
+    // Sync nav translation badge label
+    if (app.currentTranslationSpan && app.state.translation) {
+        app.currentTranslationSpan.textContent = app.state.translation;
+    }
     app.bibleApi.setTranslation(app.state.translation || DEFAULTS.translation);
 
     document.body.classList.toggle('light-mode', !!app.state.lightMode);
@@ -155,6 +159,10 @@ export async function updateFontSize(app, size) {
 export async function changeTranslation(app, translation) {
     app.state.translation = translation;
     app.bibleApi.setTranslation(translation);
+
+    // Sync both the settings <select> and the nav badge
+    if (app.translationSelector) app.translationSelector.value = translation;
+    if (app.currentTranslationSpan) app.currentTranslationSpan.textContent = translation;
 
     lsSet('translation', translation);
 

--- a/styles.css
+++ b/styles.css
@@ -971,6 +971,19 @@ body.light-mode .crossref-item {
     transform: translateY(2px);
 }
 
+/* Translation badge — visually distinguishes from book/chapter/verse */
+.selector-btn--translation {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
+.selector-btn--translation:hover {
+    background-color: var(--primary-color);
+    color: var(--bg-primary);
+}
+
 .nav-btn {
     display: flex;
     align-items: center;
@@ -1502,6 +1515,66 @@ body.hide-verse-numbers .verse .verse-num {
     background-color: var(--text-muted);
     border-radius: 2px;
     opacity: 0.5;
+}
+
+/* Translation modal — small centered dialog */
+#translationModal .modal-content {
+    max-width: 380px;
+}
+
+.modal-content--sm {
+    max-width: 380px;
+}
+
+/* Translation list */
+.translation-modal-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+}
+
+.translation-modal-item {
+    display: flex;
+    align-items: baseline;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md) var(--spacing-lg);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    transition: background-color var(--transition-fast), color var(--transition-fast);
+    border: 1px solid transparent;
+}
+
+.translation-modal-item:hover {
+    background-color: var(--bg-tertiary);
+    border-color: var(--border-color);
+}
+
+.translation-modal-item--active {
+    background-color: color-mix(in srgb, var(--primary-color) 14%, transparent);
+    border-color: var(--primary-color);
+}
+
+.translation-modal-item__name {
+    font-family: var(--font-sans);
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: var(--primary-color);
+    min-width: 3.5rem;
+}
+
+.translation-modal-item--active .translation-modal-item__name {
+    color: var(--primary-light);
+}
+
+.translation-modal-item__desc {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 /* References Modal (Bottom Sheet) */

--- a/styles.css
+++ b/styles.css
@@ -275,6 +275,13 @@ body.onyx-theme {
     --shadow-lg: 0 10px 15px rgba(255, 255, 255, 0.15);
 }
 
+/* Onyx: force passage-container to pure OLED black in dark mode */
+:root.onyx-theme .passage-container,
+html.onyx-theme .passage-container,
+body.onyx-theme .passage-container {
+    background-color: #000;
+}
+
 :root.onyx-theme.light-mode,
 html.onyx-theme.light-mode,
 body.onyx-theme.light-mode {

--- a/styles.css
+++ b/styles.css
@@ -978,16 +978,15 @@ body.light-mode .crossref-item {
     transform: translateY(2px);
 }
 
-/* Translation badge — visually distinguishes from book/chapter/verse */
+/* Translation badge — same idle style as book/chapter/verse; accent only on hover */
 .selector-btn--translation {
-    border-color: var(--primary-color);
-    color: var(--primary-color);
     font-weight: 600;
     letter-spacing: 0.03em;
 }
 
 .selector-btn--translation:hover {
     background-color: var(--primary-color);
+    border-color: var(--primary-color);
     color: var(--bg-primary);
 }
 
@@ -1017,6 +1016,16 @@ body.light-mode .crossref-item {
 .nav-btn:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+}
+
+/* Suppress focus ring on mouse click; show for keyboard navigation only */
+.nav-btn:focus:not(:focus-visible) {
+    outline: none;
+}
+
+.nav-btn:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
 }
 
 /* Passage Content */

--- a/ui.js
+++ b/ui.js
@@ -22,6 +22,9 @@ const REQUIRED_IDS = [
 	'footnotesSection', 'footnotesContent',
 	'crossReferencesSection', 'crossReferencesContent',
 	'toast',
+	// Nav translation badge
+	'translationSelectorBtn', 'currentTranslation',
+	'translationModal', 'closeTranslationModal', 'translationList',
 ];
 
 export function cacheElements(app) {
@@ -50,6 +53,15 @@ export function cacheElements(app) {
 	app.currentBookSpan = document.getElementById('currentBook');
 	app.currentChapterSpan = document.getElementById('currentChapter');
 	app.currentVerseSpan = document.getElementById('currentVerse');
+
+	// Nav translation badge
+	app.translationSelectorBtn = document.getElementById('translationSelectorBtn');
+	app.currentTranslationSpan = document.getElementById('currentTranslation');
+
+	// Translation picker modal
+	app.translationModal = document.getElementById('translationModal');
+	app.closeTranslationModal = document.getElementById('closeTranslationModal');
+	app.translationList = document.getElementById('translationList');
 
 	// Search
 	app.searchContainer = document.getElementById('searchContainer');


### PR DESCRIPTION
Merges the CSS fixes from `ts` into `dev`.

### Changes
- **`.nav-btn`** — suppress focus ring on mouse click via `:focus:not(:focus-visible)`; retain ring for keyboard navigation via `:focus-visible`
- **`.selector-btn--translation`** — remove always-on primary-color border/text from base rule; move accent to `:hover` only so it matches the neutral idle style of the Book/Chapter/Verse buttons

Closes #152