### PR TITLE
Merge exp into dev

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ import {
     scrollToVerse as scrollVerse,
     applyVerseGlow as glowVerse,
 } from './reading-state.js';
-import { cacheElements, loadTheme, toggleTheme, changeColorTheme } from './ui.js';
+import { cacheElements, loadTheme, changeColorTheme, applyLightMode } from './ui.js';
 import {
     initializeBibleStructure,
     buildBibleBooks,

--- a/app.js
+++ b/app.js
@@ -598,7 +598,9 @@ class BibleApp {
 
     /**
      * Rebuild app.bibleBooks from a translation's meta.json.
-     * Called by changeTranslation() after it fetches the incoming translation's meta.
+     * Called by changeTranslation() after it fetches the incoming translation's meta,
+     * and by _loadTranslationRegistry() on initial load so a deuterocanonical
+     * translation restored from localStorage shows all its books immediately.
      * If meta is null or has no books array, falls back to the static 66-book structure.
      * If the book modal is currently open, re-renders it so the user sees the new list.
      *
@@ -875,15 +877,18 @@ class BibleApp {
             for (const t of translations) this._copyrightMap[t.id] = t.copyright || '';
             this.updateCopyright?.();
 
-            // Fetch the starting translation's meta.json so the fallback search
-            // path knows its canon from the first search. Fire-and-forget — a
-            // failure here is harmless; the fallback just uses BOOK_LOAD_ORDER.
+            // Fetch the starting translation's meta.json to populate the book
+            // list for search and — critically — to rebuild app.bibleBooks so
+            // the book picker shows the correct canon (including Deuterocanon)
+            // when a deuterocanonical translation is restored from localStorage
+            // on page refresh without a changeTranslation call.
             const startingTranslation = this.state.translation;
             fetch(`./translations/${startingTranslation}/meta.json`)
                 .then(r => (r.ok ? r.json() : null))
                 .then(meta => {
                     if (meta?.books?.length) {
                         this.bibleApi.setBookList(startingTranslation, meta.books.map(b => b.name));
+                        this._rebuildBibleBooks(meta);
                         this._dbgEvent(`setBookList: ${startingTranslation} (${meta.books.length} books)`);
                     }
                 })

--- a/auth.js
+++ b/auth.js
@@ -186,7 +186,7 @@ export async function handleSignup(app) {
             showCrossReferences: app.state.showCrossReferences,
             verseByVerse: app.state.verseByVerse,
             colorTheme: app.state.colorTheme,
-            lightMode: app.state.lightMode,
+            lightMode: app.state.lightMode ?? 'system',
             translation: app.state.translation || 'ESV',
         });
 
@@ -226,7 +226,13 @@ export async function loadUserData(app, normalizeTranslation) {
     app.state.showCrossReferences  = s.showCrossReferences;
     app.state.verseByVerse         = s.verseByVerse;
     app.state.colorTheme           = s.colorTheme;
-    app.state.lightMode            = s.lightMode;
+    // Migrate old boolean values from Firebase to string enum
+    app.state.lightMode =
+        s.lightMode === 'light' || s.lightMode === 'dark' || s.lightMode === 'system'
+            ? s.lightMode
+            : s.lightMode === true ? 'light'
+            : s.lightMode === false ? 'dark'
+            : 'system';
     app.state.translation          = normalizeTranslation(s.translation || 'ESV');
 
     if (s.fontSize            != null) lsSet('fontSize',             s.fontSize);
@@ -236,7 +242,7 @@ export async function loadUserData(app, normalizeTranslation) {
     if (s.showCrossReferences != null) lsSet('showCrossReferences',  s.showCrossReferences);
     if (s.verseByVerse        != null) lsSet('verseByVerse',         s.verseByVerse);
     if (s.colorTheme          != null) lsSet('colorTheme',           s.colorTheme);
-    if (s.lightMode           != null) lsSet('lightMode',            s.lightMode);
+    if (s.lightMode           != null) lsSet('lightMode',            app.state.lightMode);
     if (s.translation         != null) lsSet('translation',          normalizeTranslation(s.translation || 'ESV'));
 }
 

--- a/config/firebase-config.bundle.js
+++ b/config/firebase-config.bundle.js
@@ -9,12 +9,7 @@ import {
   setPersistence,
   indexedDBLocalPersistence,
   browserLocalPersistence,
-  browserSessionPersistence,
-  EmailAuthProvider,
-  reauthenticateWithCredential,
-  verifyBeforeUpdateEmail,
-  updatePassword,
-  sendPasswordResetEmail
+  browserSessionPersistence
 } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 import {
   getDatabase,
@@ -67,12 +62,7 @@ var authShim = {
   signOut: () => signOut(_auth),
   get currentUser() {
     return _auth.currentUser;
-  },
-  reauthenticateWithCredential: (user, credential) => reauthenticateWithCredential(user, credential),
-  verifyBeforeUpdateEmail: (user, newEmail) => verifyBeforeUpdateEmail(user, newEmail),
-  updatePassword: (user, newPassword) => updatePassword(user, newPassword),
-  sendPasswordResetEmail: (email) => sendPasswordResetEmail(_auth, email),
-  createCredential: (email, password) => EmailAuthProvider.credential(email, password)
+  }
 };
 window.firebaseAuth = authShim;
 window.firebaseDatabase = dbShim;

--- a/css/modals.css
+++ b/css/modals.css
@@ -236,3 +236,14 @@
     display: flex;
     gap: var(--spacing-sm);
 }
+
+#userMenuModal .modal-content {
+    max-width: 360px;
+}
+
+.user-info-box p {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    word-break: break-all;
+}

--- a/css/modals.css
+++ b/css/modals.css
@@ -232,5 +232,7 @@
     position: relative;
 }
 
-
-
+.account-actions {
+    display: flex;
+    gap: var(--spacing-sm);
+}

--- a/events.js
+++ b/events.js
@@ -2,7 +2,7 @@
 // Wires all DOM event listeners to BibleApp instance methods.
 // New feature bindings go here — app.js does not need to change.
 
-import { toggleTheme, changeColorTheme } from './ui.js';
+import { setLightMode, changeColorTheme, applyLightMode } from './ui.js';
 import { attachDragToResize } from './modals.js';
 import { runMegasearch, performKeywordSearch } from './search.js';
 import { applyReadingFont } from './settings.js';
@@ -212,9 +212,8 @@ export function attachEventListeners(app) {
     app.translationSelector?.addEventListener('change', async (e) => app.changeTranslation(e.target.value));
 
     // ── Theme ────────────────────────────────────────────────────
-    app.themeToggleBtn?.addEventListener('click', () => toggleTheme(app));
-    document.getElementById('themeSelector')?.addEventListener('change',   (e) => changeColorTheme(app, e.target.value));
-    document.getElementById('lightModeToggle')?.addEventListener('change', () => toggleTheme(app));
+    document.getElementById('themeSelector')?.addEventListener('change', (e) => changeColorTheme(app, e.target.value));
+    document.getElementById('lightModeSelect')?.addEventListener('change', (e) => setLightMode(app, e.target.value));
 
     // ── Auth ─────────────────────────────────────────────────────
     document.getElementById('userBtn')?.addEventListener('click', () => app.handleUserButtonClick());
@@ -255,4 +254,10 @@ export function attachEventListeners(app) {
 
     // ── Keyboard ────────────────────────────────────────────────
     document.addEventListener('keydown', (e) => app.handleKeyboardShortcuts(e));
+    // Live-update appearance when OS dark/light mode changes
+    window.matchMedia('(prefers-color-scheme: light)')
+        .addEventListener('change', () => {
+            if (app.state.lightMode === 'system') applyLightMode('system');
+        });
+
 }

--- a/events.js
+++ b/events.js
@@ -162,7 +162,7 @@ export function attachEventListeners(app) {
         app.bookModal, app.chapterModal, app.verseModal,
         app.settingsModal, app.helpModal, app.loginModal,
         app.signupModal, app.userMenuModal, app.referencesModal,
-        app.translationModal,
+        app.translationModal, app.deuterocanonInfoModal,
     ].forEach((modal) => {
         if (!modal) return;
         modal.addEventListener('click', (e) => { if (e.target === modal) app.closeModal(modal); });

--- a/index.html
+++ b/index.html
@@ -524,7 +524,7 @@
                                         <button id="changeEmailBtn" class="secondary-btn">Change Email</button>
                                         <button id="changePasswordBtn" class="secondary-btn">Change Password</button>
                                 </div>
-                                <button id="logoutBtn" class="primary-btn" style="width: 100%; margin-top: var(--spacing-md)">Sign Out</button>
+                                <button id="logoutBtn" class="primary-btn" style="margin-top: var(--spacing-md)">Sign Out</button>
                         </div>
                 </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -556,13 +556,13 @@
 	<div id="deuterocanonInfoModal" class="modal">
 		<div class="modal-content modal-content--sm">
 			<div class="modal-header">
-				<h3>About the Deuterocanon</h3>
+				<h3>About the Apocrypha</h3>
 				<button class="close-btn" id="closeDeuterocanonInfoModal">&#xD7;</button>
 			</div>
 			<div class="modal-body">
 				<div class="deuterocanon-info-content">
-					<h4>What is the Deuterocanon?</h4>
-					<p>The <strong>Deuterocanon</strong> (also called the <strong>Apocrypha</strong>) refers to books and passages included in the Greek Septuagint and Latin Vulgate but not in the Hebrew Bible.</p>
+					<h4>What is the Apocrypha?</h4>
+					<p>The <strong>Apocrypha</strong> (also called the <strong>Deuterocanon</strong>) refers to books and passages included in the Greek Septuagint and Latin Vulgate but not in the Hebrew Bible.</p>
 
 					<h4>Why Protestants Don't Consider Them Inspired Scripture</h4>
 					<ul>

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
                         <div class="search-input-row">
                                 <input type="text" id="searchInput" class="search-input"
                                         placeholder="Search passages or enter reference (e.g., John 3:16)" />
-                                <button id="closeSearch" class="close-btn" title="Close search">×</button>
+                                <button id="closeSearch" class="close-btn" title="Close search">&#xD7;</button>
                         </div>
                         <div class="search-options-row">
                                 <label class="search-toggle-label" for="megasearchToggle">
@@ -197,7 +197,7 @@
                 <div class="modal-content">
                         <div class="modal-header">
                                 <h3>Select a Book</h3>
-                                <button class="close-btn" id="closeBookModal">×</button>
+                                <button class="close-btn" id="closeBookModal">&#xD7;</button>
                         </div>
                         <div class="modal-body">
                                 <div class="book-category">
@@ -216,7 +216,7 @@
                 <div class="modal-content">
                         <div class="modal-header">
                                 <h3><span id="chapterModalBook">Genesis</span></h3>
-                                <button class="close-btn" id="closeChapterModal">×</button>
+                                <button class="close-btn" id="closeChapterModal">&#xD7;</button>
                         </div>
                         <div class="modal-body">
                                 <div id="chapterGrid" class="chapter-grid"></div>
@@ -228,7 +228,7 @@
                 <div class="modal-content">
                         <div class="modal-header">
                                 <h3><span id="verseModalBook">Genesis 1</span></h3>
-                                <button class="close-btn" id="closeVerseModal">×</button>
+                                <button class="close-btn" id="closeVerseModal">&#xD7;</button>
                         </div>
                         <div class="modal-body">
                                 <div id="verseGrid" class="chapter-grid"></div>
@@ -241,7 +241,7 @@
                 <div class="modal-content modal-content--sm">
                         <div class="modal-header">
                                 <h3>Translation</h3>
-                                <button class="close-btn" id="closeTranslationModal">×</button>
+                                <button class="close-btn" id="closeTranslationModal">&#xD7;</button>
                         </div>
                         <div class="modal-body">
                                 <ul id="translationList" class="translation-modal-list"></ul>
@@ -253,7 +253,7 @@
                 <div class="modal-content">
                         <div class="modal-header">
                                 <h3>Settings</h3>
-                                <button class="close-btn" id="closeSettingsModal">×</button>
+                                <button class="close-btn" id="closeSettingsModal">&#xD7;</button>
                         </div>
                         <div class="modal-body">
                                 <div class="accordion-section active" data-section="appearance">
@@ -364,26 +364,26 @@
                 <div class="modal-content">
                         <div class="modal-header">
                                 <h3>Help &amp; Keyboard Shortcuts</h3>
-                                <button class="close-btn" id="closeHelpModal">×</button>
+                                <button class="close-btn" id="closeHelpModal">&#xD7;</button>
                         </div>
                         <div class="modal-body">
                                 <div class="settings-group">
                                         <h4>Navigation Shortcuts</h4>
                                         <div class="shortcut-list">
                                                 <div class="shortcut-item">
-                                                        <kbd>H</kbd> or <kbd>←</kbd>
+                                                        <kbd>H</kbd> or <kbd>&#x2190;</kbd>
                                                         <span>Previous chapter</span>
                                                 </div>
                                                 <div class="shortcut-item">
-                                                        <kbd>L</kbd> or <kbd>→</kbd>
+                                                        <kbd>L</kbd> or <kbd>&#x2192;</kbd>
                                                         <span>Next chapter</span>
                                                 </div>
                                                 <div class="shortcut-item">
-                                                        <kbd>K</kbd> or <kbd>↑</kbd>
+                                                        <kbd>K</kbd> or <kbd>&#x2191;</kbd>
                                                         <span>Previous verse</span>
                                                 </div>
                                                 <div class="shortcut-item">
-                                                        <kbd>J</kbd> or <kbd>↓</kbd>
+                                                        <kbd>J</kbd> or <kbd>&#x2193;</kbd>
                                                         <span>Next verse</span>
                                                 </div>
                                         </div>
@@ -448,7 +448,7 @@
                 <div class="modal-content">
                         <div class="modal-header">
                                 <h3>Sign In</h3>
-                                <button class="close-btn" id="closeLoginModal">×</button>
+                                <button class="close-btn" id="closeLoginModal">&#xD7;</button>
                         </div>
                         <div class="modal-body">
                                 <form id="loginForm" class="auth-form">
@@ -479,7 +479,7 @@
                 <div class="modal-content">
                         <div class="modal-header">
                                 <h3>Create Account</h3>
-                                <button class="close-btn" id="closeSignupModal">×</button>
+                                <button class="close-btn" id="closeSignupModal">&#xD7;</button>
                         </div>
                         <div class="modal-body">
                                 <form id="signupForm" class="auth-form">
@@ -507,7 +507,7 @@
                 <div class="modal-content">
                         <div class="modal-header">
                                 <h3>Account</h3>
-                                <button class="close-btn" id="closeUserMenuModal">×</button>
+                                <button class="close-btn" id="closeUserMenuModal">&#xD7;</button>
                         </div>
                         <div class="modal-body">
                                 <div class="user-info-box">
@@ -546,7 +546,7 @@
 		<div class="modal-content">
 			<div class="modal-header">
 				<h3>References</h3>
-				<button class="close-btn" id="closeReferencesModal">×</button>
+				<button class="close-btn" id="closeReferencesModal">&#xD7;</button>
 			</div>
 			<div class="modal-body"></div>
 		</div>
@@ -557,10 +557,31 @@
 		<div class="modal-content modal-content--sm">
 			<div class="modal-header">
 				<h3>About the Deuterocanon</h3>
-				<button class="close-btn" id="closeDeuterocanonInfoModal">×</button>
+				<button class="close-btn" id="closeDeuterocanonInfoModal">&#xD7;</button>
 			</div>
 			<div class="modal-body">
-				<p>The Deuterocanon (also called the Apocrypha) consists of books accepted as canonical by Catholic and Orthodox traditions but not included in the Hebrew Bible or most Protestant canons. These texts appear in translations such as the NRSVUE.</p>
+				<div class="deuterocanon-info-content">
+					<h4>What is the Deuterocanon?</h4>
+					<p>The <strong>Deuterocanon</strong> (also called the <strong>Apocrypha</strong>) refers to books and passages included in the Greek Septuagint and Latin Vulgate but not in the Hebrew Bible.</p>
+
+					<h4>Why Protestants Don't Consider Them Inspired Scripture</h4>
+					<ul>
+						<li>Not included in the Hebrew canon</li>
+						<li>Never quoted as Scripture by Jesus or the Apostles</li>
+						<li>Contain teachings inconsistent with the rest of Scripture (e.g., prayers for the dead in 2 Macc 12:44&#x2013;46)</li>
+					</ul>
+
+					<h4>What Reformers Said About Reading It</h4>
+					<blockquote>
+						<strong>Martin Luther (1534):</strong> &#x201C;Apocrypha, that is, books not considered equal to Holy Scripture, but which are still useful and good to read.&#x201D;
+					</blockquote>
+					<blockquote>
+						<strong>Thirty-Nine Articles (1563):</strong> &#x201C;The other books the Church doth read for example of life and instruction of manners; but yet doth it not apply them to establish any doctrine.&#x201D;
+					</blockquote>
+					<blockquote>
+						<strong>Belgic Confession (1561):</strong> &#x201C;The church may certainly read these books and learn from them as far as they agree with the canonical books.&#x201D;
+					</blockquote>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/index.html
+++ b/index.html
@@ -280,10 +280,13 @@
                                                                 <small class="help-text">Choose your preferred color scheme.</small>
                                                         </div>
                                                         <div class="setting-item">
-                                                                <label class="checkbox-label">
-                                                                        <input type="checkbox" id="lightModeToggle" />
-                                                                        <span>Light Mode</span>
-                                                                </label>
+                                                                <label for="lightModeSelect">Appearance</label>
+                                                                <select id="lightModeSelect" class="input-field">
+                                                                        <option value="system">System Default</option>
+                                                                        <option value="light">Light</option>
+                                                                        <option value="dark">Dark</option>
+                                                                </select>
+                                                                <small class="help-text">Follow your device setting or choose a fixed mode.</small>
                                                         </div>
                                                         <div class="setting-item">
                                                                 <label for="fontSizeSlider">Font Size</label>

--- a/index.html
+++ b/index.html
@@ -561,17 +561,13 @@
 			</div>
 			<div class="modal-body">
 				<div class="deuterocanon-info-content">
-					<h4>What is the Apocrypha?</h4>
-					<p>The <strong>Apocrypha</strong> (also called the <strong>Deuterocanon</strong>) refers to books and passages included in the Greek Septuagint and Latin Vulgate but not in the Hebrew Bible.</p>
+					<h4>What is the Deuterocanon?</h4>
+					<p>The Deuterocanon, also called the Apocrypha, is a set of Jewish writings from roughly 400&#x2013;50 BC, the period between the Old and New Testaments. It includes books such as Tobit, Judith, 1 &amp; 2 Maccabees, Sirach, and Wisdom of Solomon.</p>
 
-					<h4>Why Protestants Don't Consider Them Inspired Scripture</h4>
-					<ul>
-						<li>Not included in the Hebrew canon</li>
-						<li>Never quoted as Scripture by Jesus or the Apostles</li>
-						<li>Contain teachings inconsistent with the rest of Scripture (e.g., prayers for the dead in 2 Macc 12:44&#x2013;46)</li>
-					</ul>
+					<h4>Who accepts them as Scripture?</h4>
+					<p>Catholic and Orthodox Christians consider these books canonical. Most Protestants do not, following the Hebrew Bible&#x2019;s narrower canon. The books were never cited as Scripture by Jesus or the Apostles, and some passages are difficult to reconcile with the rest of Scripture, for example prayers for the dead in 2 Maccabees 12.</p>
 
-					<h4>What Reformers Said About Reading It</h4>
+					<h4>What did the Reformers say?</h4>
 					<blockquote>
 						<strong>Martin Luther (1534):</strong> &#x201C;Apocrypha, that is, books not considered equal to Holy Scripture, but which are still useful and good to read.&#x201D;
 					</blockquote>
@@ -581,6 +577,9 @@
 					<blockquote>
 						<strong>Belgic Confession (1561):</strong> &#x201C;The church may certainly read these books and learn from them as far as they agree with the canonical books.&#x201D;
 					</blockquote>
+
+					<h4>Why are they here?</h4>
+					<p>They are included for study and historical interest. These writings shaped Jewish thought in the centuries before Christ and appear in translations used by billions of Christians worldwide.</p>
 				</div>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -2,543 +2,544 @@
 <html lang="en">
 
 <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Bible Reader</title>
-        <meta name="build-id" content="__BUILD_ID__" />
-        <link rel="manifest" href="./site.webmanifest" />
-        <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png" />
-        <link rel="icon" href="./favicon.ico" />
-        <!-- Preconnect to external hosts used on first load -->
-        <link rel="preconnect" href="https://esv-bible-6dffb-default-rtdb.firebaseio.com" />
-        <link rel="preconnect" href="https://www.gstatic.com" />
-        <link rel="preconnect" href="https://www.google.com" />
-        <link rel="preconnect" href="https://apis.google.com" />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-        <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
-        <!-- Preload all ES modules so the browser fetches them in parallel
-             before the parser reaches <script type="module" src="app.js">.
-             This eliminates the sequential module-discovery waterfall. -->
-        <link rel="modulepreload" href="app.js" />
-        <link rel="modulepreload" href="bible-api.js" />
-        <link rel="modulepreload" href="bsb-structure.js" />
-        <link rel="modulepreload" href="reading-state.js" />
-        <link rel="modulepreload" href="ui.js" />
-        <link rel="modulepreload" href="bible-structure.js" />
-        <link rel="modulepreload" href="navigation.js" />
-        <link rel="modulepreload" href="search.js" />
-        <link rel="modulepreload" href="auth.js" />
-        <link rel="modulepreload" href="modals.js" />
-        <link rel="modulepreload" href="settings.js" />
-        <link rel="modulepreload" href="keyboard.js" />
-        <link rel="modulepreload" href="events.js" />
-        <!-- Preload reading fonts so the browser fetches them early,
-             preventing a late font-discovery stall that inflates LCP. -->
-        <link rel="preload" href="./fonts/GentiumBookPlus-Regular.woff2" as="font" type="font/woff2" crossorigin />
-        <link rel="preload" href="./fonts/Andika-Regular.woff2" as="font" type="font/woff2" crossorigin />
-        <link rel="preload" href="./fonts/OpenDyslexic3-Regular.woff2" as="font" type="font/woff2" crossorigin />
-        <link rel="preload" href="./fonts/Ubuntu-Regular.woff2" as="font" type="font/woff2" crossorigin />
-        <!-- CSS loaded as parallel <link> tags — @import chains are render-blocking
-             and sequential; <link> tags are fetched in parallel by the browser. -->
-        <link rel="stylesheet" href="css/fonts.css" />
-        <link rel="stylesheet" href="css/base.css" />
-        <link rel="stylesheet" href="css/tokens.css" />
-        <link rel="stylesheet" href="css/themes.css" />
-        <link rel="stylesheet" href="css/layout.css" />
-        <link rel="stylesheet" href="css/components.css" />
-        <link rel="stylesheet" href="css/modals.css" />
-        <link rel="stylesheet" href="css/interactions.css" />
-        <link rel="stylesheet" href="css/utilities.css" />
-        <link rel="stylesheet" href="css/pericope.css" />
-        <!-- reCAPTCHA v3 — required for Firebase App Check token exchange -->
-        <script src="https://www.google.com/recaptcha/api.js?render=6Lf8bAAtAAAAALvK77sjk7750S7XVUQR7Ai2cXXV" async defer></script>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Bible Reader</title>
+	<meta name="build-id" content="__BUILD_ID__" />
+	<link rel="manifest" href="./site.webmanifest" />
+	<link rel="apple-touch-icon" href="./apple-touch-icon.png" />
+	<link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png" />
+	<link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png" />
+	<link rel="icon" href="./favicon.ico" />
+	<!-- Preconnect to external hosts used on first load -->
+	<link rel="preconnect" href="https://esv-bible-6dffb-default-rtdb.firebaseio.com" />
+	<link rel="preconnect" href="https://www.gstatic.com" />
+	<link rel="preconnect" href="https://www.google.com" />
+	<link rel="preconnect" href="https://apis.google.com" />
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+	<!-- Preload all ES modules so the browser fetches them in parallel
+	     before the parser reaches <script type="module" src="app.js">.
+	     This eliminates the sequential module-discovery waterfall. -->
+	<link rel="modulepreload" href="app.js" />
+	<link rel="modulepreload" href="bible-api.js" />
+	<link rel="modulepreload" href="bsb-structure.js" />
+	<link rel="modulepreload" href="reading-state.js" />
+	<link rel="modulepreload" href="ui.js" />
+	<link rel="modulepreload" href="bible-structure.js" />
+	<link rel="modulepreload" href="navigation.js" />
+	<link rel="modulepreload" href="search.js" />
+	<link rel="modulepreload" href="auth.js" />
+	<link rel="modulepreload" href="modals.js" />
+	<link rel="modulepreload" href="settings.js" />
+	<link rel="modulepreload" href="keyboard.js" />
+	<link rel="modulepreload" href="events.js" />
+	<!-- Preload reading fonts so the browser fetches them early,
+	     preventing a late font-discovery stall that inflates LCP. -->
+	<link rel="preload" href="./fonts/GentiumBookPlus-Regular.woff2" as="font" type="font/woff2" crossorigin />
+	<link rel="preload" href="./fonts/Andika-Regular.woff2" as="font" type="font/woff2" crossorigin />
+	<link rel="preload" href="./fonts/OpenDyslexic3-Regular.woff2" as="font" type="font/woff2" crossorigin />
+	<link rel="preload" href="./fonts/Ubuntu-Regular.woff2" as="font" type="font/woff2" crossorigin />
+	<!-- CSS loaded as parallel <link> tags — @import chains are render-blocking
+	     and sequential; <link> tags are fetched in parallel by the browser. -->
+	<link rel="stylesheet" href="css/fonts.css" />
+	<link rel="stylesheet" href="css/base.css" />
+	<link rel="stylesheet" href="css/tokens.css" />
+	<link rel="stylesheet" href="css/themes.css" />
+	<link rel="stylesheet" href="css/layout.css" />
+	<link rel="stylesheet" href="css/components.css" />
+	<link rel="stylesheet" href="css/modals.css" />
+	<link rel="stylesheet" href="css/interactions.css" />
+	<link rel="stylesheet" href="css/utilities.css" />
+	<link rel="stylesheet" href="css/pericope.css" />
+	<!-- reCAPTCHA v3 — required for Firebase App Check token exchange -->
+	<script src="https://www.google.com/recaptcha/api.js?render=6Lf8bAAtAAAAALvK77sjk7750S7XVUQR7Ai2cXXV" async defer></script>
 </head>
 
 <body class="initializing">
-        <div id="topChrome" class="top-chrome">
-                <header class="header">
-                        <div class="header-content">
-                                <h1 class="logo">Lege Lux</h1>
-                                <span id="build-info">__BUILD_INFO__</span>
-                                <div class="header-controls">
-                                        <button class="icon-btn" id="searchToggle" title="Search (Ctrl+K)">
-                                                <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-                                                </svg>
-                                        </button>
+	<div id="topChrome" class="top-chrome">
+		<header class="header">
+			<div class="header-content">
+				<h1 class="logo">Lege Lux</h1>
+				<span id="build-info">__BUILD_INFO__</span>
+				<div class="header-controls">
+					<button class="icon-btn" id="searchToggle" title="Search (Ctrl+K)">
+						<svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+								d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+						</svg>
+					</button>
 
-                                        <button class="icon-btn" id="helpBtn" title="Help / Shortcuts">
-                                                <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                                d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z">
-                                                        </path>
-                                                </svg>
-                                        </button>
+					<button class="icon-btn" id="helpBtn" title="Help / Shortcuts">
+						<svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+								d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z">
+							</path>
+						</svg>
+					</button>
 
-                                        <button class="icon-btn" id="settingsBtn" title="Settings">
-                                                <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z">
-                                                        </path>
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
-                                                </svg>
-                                        </button>
+					<button class="icon-btn" id="settingsBtn" title="Settings">
+						<svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+								d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z">
+							</path>
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+								d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+						</svg>
+					</button>
 
-                                        <button class="icon-btn" id="userBtn" title="Account">
-                                                <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
-                                                </svg>
-                                        </button>
-                                </div>
-                        </div>
-                </header>
+					<button class="icon-btn" id="userBtn" title="Account">
+						<svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+								d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+						</svg>
+					</button>
+				</div>
+			</div>
+		</header>
 
-                <nav class="navigation">
-                        <div class="nav-content">
-                                <button id="prevChapter" class="nav-btn">
-                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                                <polyline points="15 18 9 12 15 6"></polyline>
-                                        </svg>
-                                        <span>Previous</span>
-                                </button>
+		<nav class="navigation">
+			<div class="nav-content">
+				<button id="prevChapter" class="nav-btn">
+					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<polyline points="15 18 9 12 15 6"></polyline>
+					</svg>
+					<span>Previous</span>
+				</button>
 
-                                <div class="passage-selector">
-                                        <button id="bookSelector" class="selector-btn">
-                                                <span id="currentBook">
-                                                        <span class="book-abbr">Gen</span>
-                                                        <span class="book-full">Genesis</span>
-                                                </span>
-                                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                                        stroke-width="2">
-                                                        <polyline points="6 9 12 15 18 9"></polyline>
-                                                </svg>
-                                        </button>
+				<div class="passage-selector">
+					<button id="bookSelector" class="selector-btn">
+						<span id="currentBook">
+							<span class="book-abbr">Gen</span>
+							<span class="book-full">Genesis</span>
+						</span>
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+							stroke-width="2">
+							<polyline points="6 9 12 15 18 9"></polyline>
+						</svg>
+					</button>
 
-                                        <button id="chapterSelector" class="selector-btn">
-                                                <span id="currentChapter">1</span>
-                                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                                        stroke-width="2">
-                                                        <polyline points="6 9 12 15 18 9"></polyline>
-                                                </svg>
-                                        </button>
+					<button id="chapterSelector" class="selector-btn">
+						<span id="currentChapter">1</span>
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+							stroke-width="2">
+							<polyline points="6 9 12 15 18 9"></polyline>
+						</svg>
+					</button>
 
-                                        <button id="verseSelector" class="selector-btn">
-                                                <span id="currentVerse">1</span>
-                                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                                        stroke-width="2">
-                                                        <polyline points="6 9 12 15 18 9"></polyline>
-                                                </svg>
-                                        </button>
+					<button id="verseSelector" class="selector-btn">
+						<span id="currentVerse">1</span>
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+							stroke-width="2">
+							<polyline points="6 9 12 15 18 9"></polyline>
+						</svg>
+					</button>
 
-                                        <button id="translationSelectorBtn" class="selector-btn selector-btn--translation" title="Change translation">
-                                                <span id="currentTranslation">KJV</span>
-                                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                                        stroke-width="2">
-                                                        <polyline points="6 9 12 15 18 9"></polyline>
-                                                </svg>
-                                        </button>
-                                </div>
+					<button id="translationSelectorBtn" class="selector-btn selector-btn--translation" title="Change translation">
+						<span id="currentTranslation">KJV</span>
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+							stroke-width="2">
+							<polyline points="6 9 12 15 18 9"></polyline>
+						</svg>
+					</button>
+				</div>
 
-                                <button id="nextChapter" class="nav-btn">
-                                        <span>Next</span>
-                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                                <polyline points="9 18 15 12 9 6"></polyline>
-                                        </svg>
-                                </button>
-                        </div>
-                </nav>
-        </div>
-
-        <div id="searchContainer" class="search-container">
-                <div class="search-wrapper">
-                        <div class="search-input-row">
-                                <input type="text" id="searchInput" class="search-input"
-                                        placeholder="Search passages or enter reference (e.g., John 3:16)" />
-                                <button id="closeSearch" class="close-btn" title="Close search">&#xD7;</button>
-                        </div>
-                        <div class="search-options-row">
-                                <label class="search-toggle-label" for="megasearchToggle">
-                                        <input type="checkbox" id="megasearchToggle" class="search-toggle-checkbox" />
-                                        <span class="search-toggle-track"></span>
-                                        <span class="search-toggle-text">Search all translations</span>
-                                </label>
-                        </div>
-                </div>
-                <div id="searchResults" class="search-results"></div>
-        </div>
-
-        <main class="main-content">
-                <div class="passage-container">
-                        <div class="passage-header">
-                                <h2 id="passageTitle" class="passage-title">Genesis 1</h2>
-                                <button id="copyPassage" class="icon-btn" aria-label="Copy passage" title="Copy passage">
-                                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-                                        </svg>
-                                </button>
-                        </div>
-                        <div id="passageText" class="passage-text">
-                                <div class="loading">Loading passage...</div>
-                        </div>
-                        <div class="passage-footer">
-                                <p id="copyright" class="copyright"></p>
-                        </div>
-                </div>
-        </main>
-
-        <div id="bookModal" class="modal">
-                <div class="modal-content">
-                        <div class="modal-header">
-                                <h3>Select a Book</h3>
-                                <button class="close-btn" id="closeBookModal">&#xD7;</button>
-                        </div>
-                        <div class="modal-body">
-                                <div class="book-category">
-                                        <h4>Old Testament</h4>
-                                        <div id="oldTestamentBooks" class="book-grid"></div>
-                                </div>
-                                <div class="book-category">
-                                        <h4>New Testament</h4>
-                                        <div id="newTestamentBooks" class="book-grid"></div>
-                                </div>
-                        </div>
-                </div>
-        </div>
-
-        <div id="chapterModal" class="modal">
-                <div class="modal-content">
-                        <div class="modal-header">
-                                <h3><span id="chapterModalBook">Genesis</span></h3>
-                                <button class="close-btn" id="closeChapterModal">&#xD7;</button>
-                        </div>
-                        <div class="modal-body">
-                                <div id="chapterGrid" class="chapter-grid"></div>
-                        </div>
-                </div>
-        </div>
-
-        <div id="verseModal" class="modal">
-                <div class="modal-content">
-                        <div class="modal-header">
-                                <h3><span id="verseModalBook">Genesis 1</span></h3>
-                                <button class="close-btn" id="closeVerseModal">&#xD7;</button>
-                        </div>
-                        <div class="modal-body">
-                                <div id="verseGrid" class="chapter-grid"></div>
-                        </div>
-                </div>
-        </div>
-
-        <!-- Translation picker modal -->
-        <div id="translationModal" class="modal">
-                <div class="modal-content modal-content--sm">
-                        <div class="modal-header">
-                                <h3>Translation</h3>
-                                <button class="close-btn" id="closeTranslationModal">&#xD7;</button>
-                        </div>
-                        <div class="modal-body">
-                                <ul id="translationList" class="translation-modal-list"></ul>
-                        </div>
-                </div>
-        </div>
-
-        <div id="settingsModal" class="modal">
-                <div class="modal-content">
-                        <div class="modal-header">
-                                <h3>Settings</h3>
-                                <button class="close-btn" id="closeSettingsModal">&#xD7;</button>
-                        </div>
-                        <div class="modal-body">
-                                <div class="accordion-section active" data-section="appearance">
-                                        <button class="accordion-header" data-target="appearance">
-                                                <span class="accordion-title">Appearance</span>
-                                                <svg class="accordion-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none"
-                                                        stroke="currentColor" stroke-width="2">
-                                                        <polyline points="6 9 12 15 18 9"></polyline>
-                                                </svg>
-                                        </button>
-                                        <div class="accordion-panel" data-panel="appearance">
-                                                <div class="settings-group">
-                                                        <div class="setting-item">
-                                                                <label for="themeSelector">Color Theme</label>
-                                                                <select id="themeSelector" class="input-field">
-                                                                        <option value="dracula">Dracula (Purple/Pink)</option>
-                                                                        <option value="onyx">Onyx (Gold/OLED)</option>
-                                                                        <option value="sage">Sage (Green/Forest)</option>
-                                                                        <option value="ember">Ember (Amber/Candlelit)</option>
-                                                                        <option value="perplexity">Perplexity (Teal/Minimal)</option>
-                                                                        <option value="basic">Basic (Black &amp; White)</option>
-                                                                        <option value="geek">The Geek Shall Inherit The Earth</option>
-                                                                </select>
-                                                                <small class="help-text">Choose your preferred color scheme.</small>
-                                                        </div>
-                                                        <div class="setting-item">
-                                                                <label for="lightModeSelect">Appearance</label>
-                                                                <select id="lightModeSelect" class="input-field">
-                                                                        <option value="system">System Default</option>
-                                                                        <option value="light">Light</option>
-                                                                        <option value="dark">Dark</option>
-                                                                </select>
-                                                                <small class="help-text">Follow your device setting or choose a fixed mode.</small>
-                                                        </div>
-                                                        <div class="setting-item">
-                                                                <label for="fontSizeSlider">Font Size</label>
-                                                                <input type="range" id="fontSizeSlider" class="slider" min="12" max="32" value="18" />
-                                                                <span id="fontSizeValue">18px</span>
-                                                        </div>
-                                                         <div class="setting-item">
-                                                                <label for="readingFontSelector">Reading Font</label>
-                                                                <select id="readingFontSelector" class="input-field">
-                                                                        <option value="gentium">Gentium Book Plus (Serif)</option>
-                                                                        <option value="andika">Andika (Sans Serif)</option>
-                                                                        <option value="ubuntu">Ubuntu</option>
-                                                                        <option value="opendyslexic3">Open Dyslexic 3</option>
-                                                                </select>
-                                                                <small class="help-text" id="readingFontHelpText">Choose the typeface used for passage text.</small>
-                                                        </div>
-                                                        <div class="setting-item">
-                                                                <label class="checkbox-label">
-                                                                        <input type="checkbox" id="verseNumbersToggle" checked />
-                                                                        <span>Show verse numbers</span>
-                                                                </label>
-                                                        </div>
-                                                        <div class="setting-item">
-                                                                <label class="checkbox-label">
-                                                                        <input type="checkbox" id="headingsToggle" checked />
-                                                                        <span>Show section headings</span>
-                                                                </label>
-                                                        </div>
-                                                        <div class="setting-item">
-                                                                <label class="checkbox-label">
-                                                                        <input type="checkbox" id="footnotesToggle" />
-                                                                        <span>Show footnotes</span>
-                                                                </label>
-                                                        </div>
-                                                        <div class="setting-item">
-                                                                <label class="checkbox-label">
-                                                                        <input type="checkbox" id="crossReferencesToggle" />
-                                                                        <span>Show cross-references</span>
-                                                                </label>
-                                                        </div>
-                                                        <div class="setting-item">
-                                                                <label class="checkbox-label">
-                                                                        <input type="checkbox" id="verseByVerseToggle" />
-                                                                        <span>Verse-by-verse display</span>
-                                                                </label>
-                                                        </div>
-                                                </div>
-                                        </div>
-                                </div>
-
-                                <div class="accordion-section" data-section="account">
-                                        <button class="accordion-header" data-target="account">
-                                                <span class="accordion-title">Account</span>
-                                                <svg class="accordion-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none"
-                                                        stroke="currentColor" stroke-width="2">
-                                                        <polyline points="6 9 12 15 18 9"></polyline>
-                                                </svg>
-                                        </button>
-                                        <div class="accordion-panel" data-panel="account">
-                                                <div class="settings-group">
-                                                        <p class="help-text">
-                                                                Account settings (email, theme, translation, reading position) are automatically synced via Firebase when you're signed in.
-                                                        </p>
-                                                        <button id="openAccountBtn" class="primary-btn" style="width: 100%; margin-top: 1rem;">
-                                                                Manage Account
-                                                        </button>
-                                                </div>
-                                        </div>
-                                </div>
-                        </div>
-                </div>
-        </div>
-
-        <div id="helpModal" class="modal">
-                <div class="modal-content">
-                        <div class="modal-header">
-                                <h3>Help &amp; Keyboard Shortcuts</h3>
-                                <button class="close-btn" id="closeHelpModal">&#xD7;</button>
-                        </div>
-                        <div class="modal-body">
-                                <div class="settings-group">
-                                        <h4>Navigation Shortcuts</h4>
-                                        <div class="shortcut-list">
-                                                <div class="shortcut-item">
-                                                        <kbd>H</kbd> or <kbd>&#x2190;</kbd>
-                                                        <span>Previous chapter</span>
-                                                </div>
-                                                <div class="shortcut-item">
-                                                        <kbd>L</kbd> or <kbd>&#x2192;</kbd>
-                                                        <span>Next chapter</span>
-                                                </div>
-                                                <div class="shortcut-item">
-                                                        <kbd>K</kbd> or <kbd>&#x2191;</kbd>
-                                                        <span>Previous verse</span>
-                                                </div>
-                                                <div class="shortcut-item">
-                                                        <kbd>J</kbd> or <kbd>&#x2193;</kbd>
-                                                        <span>Next verse</span>
-                                                </div>
-                                        </div>
-                                </div>
-
-                                <div class="settings-group">
-                                        <h4>General Shortcuts</h4>
-                                        <div class="shortcut-list">
-                                                <div class="shortcut-item">
-                                                        <kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd>
-                                                        <span>Toggle search</span>
-                                                </div>
-                                                <div class="shortcut-item">
-                                                        <kbd>T</kbd>
-                                                        <span>Open translation picker</span>
-                                                </div>
-                                                <div class="shortcut-item">
-                                                        <kbd>N</kbd>
-                                                        <span>Toggle verse numbers</span>
-                                                </div>
-                                                <div class="shortcut-item">
-                                                        <kbd>V</kbd>
-                                                        <span>Toggle verse-by-verse mode</span>
-                                                </div>
-                                                <div class="shortcut-item">
-                                                        <kbd>S</kbd>
-                                                        <span>Toggle section headings</span>
-                                                </div>
-                                                <div class="shortcut-item">
-                                                        <kbd>Esc</kbd>
-                                                        <span>Close modal / search</span>
-                                                </div>
-                                        </div>
-                                </div>
-
-                                <div class="settings-group">
-                                        <h4>Tips</h4>
-                                        <ul class="tips-list">
-                                                <li>Click on the book, chapter, or verse selector to jump to any location.</li>
-                                                <li>Search by reference to jump quickly (examples: <code>John 3</code>, <code>John 3:16</code>, <code>jn 3 16</code>).</li>
-                                                <li>Search by keywords to find mentions across the Bible (example: <code>covenant</code>).</li>
-                                                <li>Search for an exact phrase by wrapping it in double quotes (example: <code>"in love"</code>).</li>
-                                                <li>Enable "Search all translations" in the search bar to find verses unique to other translations.</li>
-                                                <li>Use Settings to change font size, display options, theme, and translation.</li>
-                                                <li>Your reading position and settings sync across devices when signed in.</li>
-                                        </ul>
-                                </div>
-
-                                <div class="settings-group">
-                                        <h4>Getting Started</h4>
-                                        <ul class="tips-list">
-                                                <li><strong>Sign Up:</strong> Create an account to sync your settings and reading position across devices.</li>
-                                                <li><strong>Customize:</strong> Adjust font size, toggle verse numbers, headings, and translation in Settings.</li>
-                                                <li><strong>Search:</strong> Use search to jump directly to references or find words and phrases across the selected translation.</li>
-                                        </ul>
-                                </div>
-                        </div>
-                </div>
-        </div>
-
-        <div id="loginModal" class="modal">
-                <div class="modal-content">
-                        <div class="modal-header">
-                                <h3>Sign In</h3>
-                                <button class="close-btn" id="closeLoginModal">&#xD7;</button>
-                        </div>
-                        <div class="modal-body">
-                                <form id="loginForm" class="auth-form">
-                                        <div class="setting-item">
-                                                <label for="loginEmail">Email</label>
-                                                <input type="email" id="loginEmail" class="input-field" placeholder="your@email.com"
-                                                        autocomplete="email" required />
-                                        </div>
-                                        <div class="setting-item">
-                                                <label for="loginPassword">Password</label>
-                                                <input type="password" id="loginPassword" class="input-field" placeholder="Password"
-                                                        autocomplete="current-password" required />
-                                        </div>
-                                        <button type="submit" class="primary-btn" style="width: 100%">Sign In</button>
-                                </form>
-                                <p class="auth-switch">
-                                        <a href="#" id="forgotPasswordLink">Forgot password?</a>
-                                </p>
-                                <p class="auth-switch">
-                                        Don't have an account?
-                                        <a href="#" id="showSignupLink">Sign up</a>
-                                </p>
-                        </div>
-                </div>
-        </div>
-
-        <div id="signupModal" class="modal">
-                <div class="modal-content">
-                        <div class="modal-header">
-                                <h3>Create Account</h3>
-                                <button class="close-btn" id="closeSignupModal">&#xD7;</button>
-                        </div>
-                        <div class="modal-body">
-                                <form id="signupForm" class="auth-form">
-                                        <div class="setting-item">
-                                                <label for="signupEmail">Email</label>
-                                                <input type="email" id="signupEmail" class="input-field" placeholder="your@email.com"
-                                                        autocomplete="email" required />
-                                        </div>
-                                        <div class="setting-item">
-                                                <label for="signupPassword">Password</label>
-                                                <input type="password" id="signupPassword" class="input-field"
-                                                        placeholder="At least 6 characters" autocomplete="new-password" required />
-                                        </div>
-                                        <button type="submit" class="primary-btn" style="width: 100%">Create Account</button>
-                                </form>
-                                <p class="auth-switch">
-                                        Already have an account?
-                                        <a href="#" id="showLoginLink">Sign in</a>
-                                </p>
-                        </div>
-                </div>
-        </div>
-
-        <div id="userMenuModal" class="modal">
-                <div class="modal-content">
-                        <div class="modal-header">
-                                <h3>Account</h3>
-                                <button class="close-btn" id="closeUserMenuModal">&#xD7;</button>
-                        </div>
-                        <div class="modal-body">
-                                <div class="user-info-box">
-                                        <p>
-                                                <strong>Email</strong>
-                                                <span id="userEmail"></span>
-                                        </p>
-                                        <p>
-                                                <strong>Theme</strong>
-                                                <span id="userTheme"></span>
-                                        </p>
-                                </div>
-                                <div class="account-actions">
-                                        <button id="changeEmailBtn" class="secondary-btn">Change Email</button>
-                                        <button id="changePasswordBtn" class="secondary-btn">Change Password</button>
-                                </div>
-                                <button id="logoutBtn" class="primary-btn" style="margin-top: var(--spacing-md)">Sign Out</button>
-                        </div>
-                </div>
-        </div>
-
-	<!-- Footnotes section (below passage text, shown when showFootnotes is on) -->
-	<div id="footnotesSection" class="passage-extras-section hidden">
-		<h4 class="passage-extras-heading">Footnotes</h4>
-		<div id="footnotesContent" class="passage-extras-content"></div>
+				<button id="nextChapter" class="nav-btn">
+					<span>Next</span>
+					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<polyline points="9 18 15 12 9 6"></polyline>
+					</svg>
+				</button>
+			</div>
+		</nav>
 	</div>
 
-	<!-- Cross-references section (below passage text, shown when showCrossReferences is on) -->
-	<div id="crossReferencesSection" class="passage-extras-section hidden">
-		<h4 class="passage-extras-heading">Cross-References</h4>
-		<div id="crossReferencesContent" class="passage-extras-content"></div>
+	<div id="searchContainer" class="search-container">
+		<div class="search-wrapper">
+			<div class="search-input-row">
+				<input type="text" id="searchInput" class="search-input"
+					placeholder="Search passages or enter reference (e.g., John 3:16)" />
+				<button id="closeSearch" class="close-btn" title="Close search">&#xD7;</button>
+			</div>
+			<div class="search-options-row">
+				<label class="search-toggle-label" for="megasearchToggle">
+					<input type="checkbox" id="megasearchToggle" class="search-toggle-checkbox" />
+					<span class="search-toggle-track"></span>
+					<span class="search-toggle-text">Search all translations</span>
+				</label>
+			</div>
+		</div>
+		<div id="searchResults" class="search-results"></div>
+	</div>
+
+	<main class="main-content">
+		<div class="passage-container">
+			<div class="passage-header">
+				<h2 id="passageTitle" class="passage-title">Genesis 1</h2>
+				<button id="copyPassage" class="icon-btn" aria-label="Copy passage" title="Copy passage">
+					<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+						<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+					</svg>
+				</button>
+			</div>
+			<div id="passageText" class="passage-text">
+				<div class="loading">Loading passage...</div>
+			</div>
+
+			<!-- Footnotes section (below passage text, shown when showFootnotes is on) -->
+			<div id="footnotesSection" class="passage-extras-section hidden">
+				<h4 class="passage-extras-heading">Footnotes</h4>
+				<div id="footnotesContent" class="passage-extras-content"></div>
+			</div>
+
+			<!-- Cross-references section (below passage text, shown when showCrossReferences is on) -->
+			<div id="crossReferencesSection" class="passage-extras-section hidden">
+				<h4 class="passage-extras-heading">Cross-References</h4>
+				<div id="crossReferencesContent" class="passage-extras-content"></div>
+			</div>
+
+			<div class="passage-footer">
+				<p id="copyright" class="copyright"></p>
+			</div>
+		</div>
+	</main>
+
+	<div id="bookModal" class="modal">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3>Select a Book</h3>
+				<button class="close-btn" id="closeBookModal">&#xD7;</button>
+			</div>
+			<div class="modal-body">
+				<div class="book-category">
+					<h4>Old Testament</h4>
+					<div id="oldTestamentBooks" class="book-grid"></div>
+				</div>
+				<div class="book-category">
+					<h4>New Testament</h4>
+					<div id="newTestamentBooks" class="book-grid"></div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div id="chapterModal" class="modal">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3><span id="chapterModalBook">Genesis</span></h3>
+				<button class="close-btn" id="closeChapterModal">&#xD7;</button>
+			</div>
+			<div class="modal-body">
+				<div id="chapterGrid" class="chapter-grid"></div>
+			</div>
+		</div>
+	</div>
+
+	<div id="verseModal" class="modal">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3><span id="verseModalBook">Genesis 1</span></h3>
+				<button class="close-btn" id="closeVerseModal">&#xD7;</button>
+			</div>
+			<div class="modal-body">
+				<div id="verseGrid" class="chapter-grid"></div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Translation picker modal -->
+	<div id="translationModal" class="modal">
+		<div class="modal-content modal-content--sm">
+			<div class="modal-header">
+				<h3>Translation</h3>
+				<button class="close-btn" id="closeTranslationModal">&#xD7;</button>
+			</div>
+			<div class="modal-body">
+				<ul id="translationList" class="translation-modal-list"></ul>
+			</div>
+		</div>
+	</div>
+
+	<div id="settingsModal" class="modal">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3>Settings</h3>
+				<button class="close-btn" id="closeSettingsModal">&#xD7;</button>
+			</div>
+			<div class="modal-body">
+				<div class="accordion-section active" data-section="appearance">
+					<button class="accordion-header" data-target="appearance">
+						<span class="accordion-title">Appearance</span>
+						<svg class="accordion-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none"
+							stroke="currentColor" stroke-width="2">
+							<polyline points="6 9 12 15 18 9"></polyline>
+						</svg>
+					</button>
+					<div class="accordion-panel" data-panel="appearance">
+						<div class="settings-group">
+							<div class="setting-item">
+								<label for="themeSelector">Color Theme</label>
+								<select id="themeSelector" class="input-field">
+									<option value="dracula">Dracula (Purple/Pink)</option>
+									<option value="onyx">Onyx (Gold/OLED)</option>
+									<option value="sage">Sage (Green/Forest)</option>
+									<option value="ember">Ember (Amber/Candlelit)</option>
+									<option value="perplexity">Perplexity (Teal/Minimal)</option>
+									<option value="basic">Basic (Black &amp; White)</option>
+									<option value="geek">The Geek Shall Inherit The Earth</option>
+								</select>
+								<small class="help-text">Choose your preferred color scheme.</small>
+							</div>
+							<div class="setting-item">
+								<label for="lightModeSelect">Appearance</label>
+								<select id="lightModeSelect" class="input-field">
+									<option value="system">System Default</option>
+									<option value="light">Light</option>
+									<option value="dark">Dark</option>
+								</select>
+								<small class="help-text">Follow your device setting or choose a fixed mode.</small>
+							</div>
+							<div class="setting-item">
+								<label for="fontSizeSlider">Font Size</label>
+								<input type="range" id="fontSizeSlider" class="slider" min="12" max="32" value="18" />
+								<span id="fontSizeValue">18px</span>
+							</div>
+							<div class="setting-item">
+								<label for="readingFontSelector">Reading Font</label>
+								<select id="readingFontSelector" class="input-field">
+									<option value="gentium">Gentium Book Plus (Serif)</option>
+									<option value="andika">Andika (Sans Serif)</option>
+									<option value="ubuntu">Ubuntu</option>
+									<option value="opendyslexic3">Open Dyslexic 3</option>
+								</select>
+								<small class="help-text" id="readingFontHelpText">Choose the typeface used for passage text.</small>
+							</div>
+							<div class="setting-item">
+								<label class="checkbox-label">
+									<input type="checkbox" id="verseNumbersToggle" checked />
+									<span>Show verse numbers</span>
+								</label>
+							</div>
+							<div class="setting-item">
+								<label class="checkbox-label">
+									<input type="checkbox" id="headingsToggle" checked />
+									<span>Show section headings</span>
+								</label>
+							</div>
+							<div class="setting-item">
+								<label class="checkbox-label">
+									<input type="checkbox" id="footnotesToggle" />
+									<span>Show footnotes</span>
+								</label>
+							</div>
+							<div class="setting-item">
+								<label class="checkbox-label">
+									<input type="checkbox" id="crossReferencesToggle" />
+									<span>Show cross-references</span>
+								</label>
+							</div>
+							<div class="setting-item">
+								<label class="checkbox-label">
+									<input type="checkbox" id="verseByVerseToggle" />
+									<span>Verse-by-verse display</span>
+								</label>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div class="accordion-section" data-section="account">
+					<button class="accordion-header" data-target="account">
+						<span class="accordion-title">Account</span>
+						<svg class="accordion-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none"
+							stroke="currentColor" stroke-width="2">
+							<polyline points="6 9 12 15 18 9"></polyline>
+						</svg>
+					</button>
+					<div class="accordion-panel" data-panel="account">
+						<div class="settings-group">
+							<p class="help-text">
+								Account settings (email, theme, translation, reading position) are automatically synced via Firebase when you're signed in.
+							</p>
+							<button id="openAccountBtn" class="primary-btn" style="width: 100%; margin-top: 1rem;">
+								Manage Account
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div id="helpModal" class="modal">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3>Help &amp; Keyboard Shortcuts</h3>
+				<button class="close-btn" id="closeHelpModal">&#xD7;</button>
+			</div>
+			<div class="modal-body">
+				<div class="settings-group">
+					<h4>Navigation Shortcuts</h4>
+					<div class="shortcut-list">
+						<div class="shortcut-item">
+							<kbd>H</kbd> or <kbd>&#x2190;</kbd>
+							<span>Previous chapter</span>
+						</div>
+						<div class="shortcut-item">
+							<kbd>L</kbd> or <kbd>&#x2192;</kbd>
+							<span>Next chapter</span>
+						</div>
+						<div class="shortcut-item">
+							<kbd>K</kbd> or <kbd>&#x2191;</kbd>
+							<span>Previous verse</span>
+						</div>
+						<div class="shortcut-item">
+							<kbd>J</kbd> or <kbd>&#x2193;</kbd>
+							<span>Next verse</span>
+						</div>
+					</div>
+				</div>
+
+				<div class="settings-group">
+					<h4>General Shortcuts</h4>
+					<div class="shortcut-list">
+						<div class="shortcut-item">
+							<kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd>
+							<span>Toggle search</span>
+						</div>
+						<div class="shortcut-item">
+							<kbd>T</kbd>
+							<span>Open translation picker</span>
+						</div>
+						<div class="shortcut-item">
+							<kbd>N</kbd>
+							<span>Toggle verse numbers</span>
+						</div>
+						<div class="shortcut-item">
+							<kbd>V</kbd>
+							<span>Toggle verse-by-verse mode</span>
+						</div>
+						<div class="shortcut-item">
+							<kbd>S</kbd>
+							<span>Toggle section headings</span>
+						</div>
+						<div class="shortcut-item">
+							<kbd>Esc</kbd>
+							<span>Close modal / search</span>
+						</div>
+					</div>
+				</div>
+
+				<div class="settings-group">
+					<h4>Tips</h4>
+					<ul class="tips-list">
+						<li>Click on the book, chapter, or verse selector to jump to any location.</li>
+						<li>Search by reference to jump quickly (examples: <code>John 3</code>, <code>John 3:16</code>, <code>jn 3 16</code>).</li>
+						<li>Search by keywords to find mentions across the Bible (example: <code>covenant</code>).</li>
+						<li>Search for an exact phrase by wrapping it in double quotes (example: <code>"in love"</code>).</li>
+						<li>Enable "Search all translations" in the search bar to find verses unique to other translations.</li>
+						<li>Use Settings to change font size, display options, theme, and translation.</li>
+						<li>Your reading position and settings sync across devices when signed in.</li>
+					</ul>
+				</div>
+
+				<div class="settings-group">
+					<h4>Getting Started</h4>
+					<ul class="tips-list">
+						<li><strong>Sign Up:</strong> Create an account to sync your settings and reading position across devices.</li>
+						<li><strong>Customize:</strong> Adjust font size, toggle verse numbers, headings, and translation in Settings.</li>
+						<li><strong>Search:</strong> Use search to jump directly to references or find words and phrases across the selected translation.</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div id="loginModal" class="modal">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3>Sign In</h3>
+				<button class="close-btn" id="closeLoginModal">&#xD7;</button>
+			</div>
+			<div class="modal-body">
+				<form id="loginForm" class="auth-form">
+					<div class="setting-item">
+						<label for="loginEmail">Email</label>
+						<input type="email" id="loginEmail" class="input-field" placeholder="your@email.com"
+							autocomplete="email" required />
+					</div>
+					<div class="setting-item">
+						<label for="loginPassword">Password</label>
+						<input type="password" id="loginPassword" class="input-field" placeholder="Password"
+							autocomplete="current-password" required />
+					</div>
+					<button type="submit" class="primary-btn" style="width: 100%">Sign In</button>
+				</form>
+				<p class="auth-switch">
+					<a href="#" id="forgotPasswordLink">Forgot password?</a>
+				</p>
+				<p class="auth-switch">
+					Don't have an account?
+					<a href="#" id="showSignupLink">Sign up</a>
+				</p>
+			</div>
+		</div>
+	</div>
+
+	<div id="signupModal" class="modal">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3>Create Account</h3>
+				<button class="close-btn" id="closeSignupModal">&#xD7;</button>
+			</div>
+			<div class="modal-body">
+				<form id="signupForm" class="auth-form">
+					<div class="setting-item">
+						<label for="signupEmail">Email</label>
+						<input type="email" id="signupEmail" class="input-field" placeholder="your@email.com"
+							autocomplete="email" required />
+					</div>
+					<div class="setting-item">
+						<label for="signupPassword">Password</label>
+						<input type="password" id="signupPassword" class="input-field"
+							placeholder="At least 6 characters" autocomplete="new-password" required />
+					</div>
+					<button type="submit" class="primary-btn" style="width: 100%">Create Account</button>
+				</form>
+				<p class="auth-switch">
+					Already have an account?
+					<a href="#" id="showLoginLink">Sign in</a>
+				</p>
+			</div>
+		</div>
+	</div>
+
+	<div id="userMenuModal" class="modal">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3>Account</h3>
+				<button class="close-btn" id="closeUserMenuModal">&#xD7;</button>
+			</div>
+			<div class="modal-body">
+				<div class="user-info-box">
+					<p>
+						<strong>Email</strong>
+						<span id="userEmail"></span>
+					</p>
+					<p>
+						<strong>Theme</strong>
+						<span id="userTheme"></span>
+					</p>
+				</div>
+				<div class="account-actions">
+					<button id="changeEmailBtn" class="secondary-btn">Change Email</button>
+					<button id="changePasswordBtn" class="secondary-btn">Change Password</button>
+				</div>
+				<button id="logoutBtn" class="primary-btn" style="margin-top: var(--spacing-md)">Sign Out</button>
+			</div>
+		</div>
 	</div>
 
 	<!-- References bottom-sheet modal -->

--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@
 					<h4>Who accepts them as Scripture?</h4>
 					<p>Catholic and Orthodox Christians consider these books canonical. Most Protestants do not, following the Hebrew Bible&#x2019;s narrower canon. The books were never cited as Scripture by Jesus or the Apostles, and some passages are difficult to reconcile with the rest of Scripture, for example prayers for the dead in 2 Maccabees 12.</p>
 
-					<h4>What did the Reformers say?</h4>
+					<h4>What did the Protestant Reformers say?</h4>
 					<blockquote>
 						<strong>Martin Luther (1534):</strong> &#x201C;Apocrypha, that is, books not considered equal to Holy Scripture, but which are still useful and good to read.&#x201D;
 					</blockquote>

--- a/index.html
+++ b/index.html
@@ -521,8 +521,8 @@
                                         </p>
                                 </div>
                                 <div class="account-actions">
-                                        <button id="changeEmailBtn" class="secondary-btn" style="width: 100%">Change Email</button>
-                                        <button id="changePasswordBtn" class="secondary-btn" style="width: 100%">Change Password</button>
+                                        <button id="changeEmailBtn" class="secondary-btn">Change Email</button>
+                                        <button id="changePasswordBtn" class="secondary-btn">Change Password</button>
                                 </div>
                                 <button id="logoutBtn" class="primary-btn" style="width: 100%; margin-top: var(--spacing-md)">Sign Out</button>
                         </div>

--- a/settings.js
+++ b/settings.js
@@ -1,7 +1,7 @@
 // settings.js
 // Reading preferences: load from storage, apply to DOM, persist to Firebase and localStorage.
 
-import { changeColorTheme, updateThemeIcon } from './ui.js';
+import { changeColorTheme, applyLightMode } from './ui.js';
 
 const DEFAULTS = {
     fontSize:            18,
@@ -10,7 +10,7 @@ const DEFAULTS = {
     showFootnotes:       false,
     showCrossReferences: false,
     verseByVerse:        false,
-    lightMode:           false,
+    lightMode:           'system',
     colorTheme:          'basic',
     translation:         'KJV',
     readingFont:         'gentium',
@@ -60,7 +60,11 @@ export function loadLocalSettings(app) {
     app.state.showFootnotes       = readBool('showFootnotes',       DEFAULTS.showFootnotes);
     app.state.showCrossReferences = readBool('showCrossReferences', DEFAULTS.showCrossReferences);
     app.state.verseByVerse        = readBool('verseByVerse',        DEFAULTS.verseByVerse);
-    app.state.lightMode           = readBool('lightMode',           DEFAULTS.lightMode);
+    const _rawLightMode = (() => { try { return localStorage.getItem('lightMode'); } catch (_) { return null; } })();
+    app.state.lightMode =
+        _rawLightMode === 'light' || _rawLightMode === 'dark' || _rawLightMode === 'system'
+            ? _rawLightMode
+            : DEFAULTS.lightMode;
 
     try { app.state.colorTheme = localStorage.getItem('colorTheme') || DEFAULTS.colorTheme; }
     catch (_) { app.state.colorTheme = DEFAULTS.colorTheme; }
@@ -99,10 +103,9 @@ export function applySettings(app) {
     }
     app.bibleApi.setTranslation(app.state.translation || DEFAULTS.translation);
 
-    document.body.classList.toggle('light-mode', !!app.state.lightMode);
-    const lightModeToggle = document.getElementById('lightModeToggle');
-    if (lightModeToggle) lightModeToggle.checked = !!app.state.lightMode;
-    updateThemeIcon(app.state.lightMode);
+    applyLightMode(app.state.lightMode);
+    const lightModeSelect = document.getElementById('lightModeSelect');
+    if (lightModeSelect) lightModeSelect.value = app.state.lightMode;
 
     document.body.classList.toggle('hide-verse-numbers', !app.state.showVerseNumbers);
     if (app.verseNumbersToggle)    app.verseNumbersToggle.checked    = !!app.state.showVerseNumbers;

--- a/settings.js
+++ b/settings.js
@@ -151,7 +151,15 @@ export async function toggleSetting(app, setting) {
         return;
     }
 
-    applySettings(app);
+    if (setting === 'showVerseNumbers') {
+        document.body.classList.toggle('hide-verse-numbers', !app.state.showVerseNumbers);
+        return;
+    }
+
+    if (setting === 'showFootnotes' || setting === 'showCrossReferences') {
+        await app.loadPassage(app.state.currentBook, app.state.currentChapter);
+        return;
+    }
 }
 
 export async function toggleVerseByVerse(app) {

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -407,7 +407,7 @@ test('settings: color theme selector applies theme to body', async ({ page }) =>
 });
 
 // ---------------------------------------------------------------------------
-// 16. Theme switch — light mode toggle
+// 16. Theme switch — 3-way Appearance select (system / light / dark)
 // ---------------------------------------------------------------------------
 test('theme switch: toggling light mode changes body class', async ({ page }) => {
         await page.goto('/');
@@ -415,14 +415,21 @@ test('theme switch: toggling light mode changes body class', async ({ page }) =>
 
         await openSettingsSection(page, 'appearance');
 
-        const toggle = page.locator('#lightModeToggle');
-        const before = await toggle.isChecked();
-        await toggle.click();
-        await expect(toggle).toBeChecked({ checked: !before });
+        const select = page.locator('#lightModeSelect');
+        await expect(select).toBeVisible();
+
+        const current = await select.inputValue();
+        // Pick a value different from current to guarantee a state change.
+        const next = current === 'light' ? 'dark' : 'light';
+        await select.selectOption(next);
+
+        await expect(select).toHaveValue(next);
 
         const bodyClass = await page.evaluate(() => document.body.className);
-        if (!before) {
+        if (next === 'light') {
                 expect(bodyClass).toMatch(/light/);
+        } else {
+                expect(bodyClass).not.toMatch(/light/);
         }
 });
 

--- a/translations/NRSVUE/meta.json
+++ b/translations/NRSVUE/meta.json
@@ -15,428 +15,92 @@
       "Critical Text"
     ],
     "textualBasis": "OT from the Masoretic Text with significant use of the Dead Sea Scrolls and Septuagint. NT from the critical Greek text (NA28). Updated 2021 revision of the NRSV with gender-inclusive language and updated scholarship.",
-    "copyright": "New Revised Standard Version, Updated Edition. Copyright © 2021 National Council of Churches of Christ in the United States of America. Verify distribution rights before publishing."
+    "copyright": "New Revised Standard Version, Updated Edition. Copyright \u00a9 2021 National Council of Churches of Christ in the United States of America. Verify distribution rights before publishing."
   },
   "books": [
-    {
-      "name": "Genesis",
-      "testament": "Old Testament",
-      "chapters": 50
-    },
-    {
-      "name": "Exodus",
-      "testament": "Old Testament",
-      "chapters": 40
-    },
-    {
-      "name": "Leviticus",
-      "testament": "Old Testament",
-      "chapters": 27
-    },
-    {
-      "name": "Numbers",
-      "testament": "Old Testament",
-      "chapters": 36
-    },
-    {
-      "name": "Deuteronomy",
-      "testament": "Old Testament",
-      "chapters": 34
-    },
-    {
-      "name": "Joshua",
-      "testament": "Old Testament",
-      "chapters": 24
-    },
-    {
-      "name": "Judges",
-      "testament": "Old Testament",
-      "chapters": 21
-    },
-    {
-      "name": "Ruth",
-      "testament": "Old Testament",
-      "chapters": 4
-    },
-    {
-      "name": "1 Samuel",
-      "testament": "Old Testament",
-      "chapters": 31
-    },
-    {
-      "name": "2 Samuel",
-      "testament": "Old Testament",
-      "chapters": 24
-    },
-    {
-      "name": "1 Kings",
-      "testament": "Old Testament",
-      "chapters": 22
-    },
-    {
-      "name": "2 Kings",
-      "testament": "Old Testament",
-      "chapters": 25
-    },
-    {
-      "name": "1 Chronicles",
-      "testament": "Old Testament",
-      "chapters": 29
-    },
-    {
-      "name": "2 Chronicles",
-      "testament": "Old Testament",
-      "chapters": 36
-    },
-    {
-      "name": "Ezra",
-      "testament": "Old Testament",
-      "chapters": 10
-    },
-    {
-      "name": "Nehemiah",
-      "testament": "Old Testament",
-      "chapters": 13
-    },
-    {
-      "name": "Esther",
-      "testament": "Old Testament",
-      "chapters": 10
-    },
-    {
-      "name": "Job",
-      "testament": "Old Testament",
-      "chapters": 42
-    },
-    {
-      "name": "Psalm",
-      "testament": "Old Testament",
-      "chapters": 150
-    },
-    {
-      "name": "Proverbs",
-      "testament": "Old Testament",
-      "chapters": 31
-    },
-    {
-      "name": "Ecclesiastes",
-      "testament": "Old Testament",
-      "chapters": 12
-    },
-    {
-      "name": "Song of Solomon",
-      "testament": "Old Testament",
-      "chapters": 8
-    },
-    {
-      "name": "Isaiah",
-      "testament": "Old Testament",
-      "chapters": 66
-    },
-    {
-      "name": "Jeremiah",
-      "testament": "Old Testament",
-      "chapters": 52
-    },
-    {
-      "name": "Lamentations",
-      "testament": "Old Testament",
-      "chapters": 5
-    },
-    {
-      "name": "Ezekiel",
-      "testament": "Old Testament",
-      "chapters": 48
-    },
-    {
-      "name": "Daniel",
-      "testament": "Old Testament",
-      "chapters": 12
-    },
-    {
-      "name": "Hosea",
-      "testament": "Old Testament",
-      "chapters": 14
-    },
-    {
-      "name": "Joel",
-      "testament": "Old Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Amos",
-      "testament": "Old Testament",
-      "chapters": 9
-    },
-    {
-      "name": "Obadiah",
-      "testament": "Old Testament",
-      "chapters": 1
-    },
-    {
-      "name": "Jonah",
-      "testament": "Old Testament",
-      "chapters": 4
-    },
-    {
-      "name": "Micah",
-      "testament": "Old Testament",
-      "chapters": 7
-    },
-    {
-      "name": "Nahum",
-      "testament": "Old Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Habakkuk",
-      "testament": "Old Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Zephaniah",
-      "testament": "Old Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Haggai",
-      "testament": "Old Testament",
-      "chapters": 2
-    },
-    {
-      "name": "Zechariah",
-      "testament": "Old Testament",
-      "chapters": 14
-    },
-    {
-      "name": "Malachi",
-      "testament": "Old Testament",
-      "chapters": 4
-    },
-    {
-      "name": "Matthew",
-      "testament": "New Testament",
-      "chapters": 28
-    },
-    {
-      "name": "Mark",
-      "testament": "New Testament",
-      "chapters": 16
-    },
-    {
-      "name": "Luke",
-      "testament": "New Testament",
-      "chapters": 24
-    },
-    {
-      "name": "John",
-      "testament": "New Testament",
-      "chapters": 21
-    },
-    {
-      "name": "Acts",
-      "testament": "New Testament",
-      "chapters": 28
-    },
-    {
-      "name": "Romans",
-      "testament": "New Testament",
-      "chapters": 16
-    },
-    {
-      "name": "1 Corinthians",
-      "testament": "New Testament",
-      "chapters": 16
-    },
-    {
-      "name": "2 Corinthians",
-      "testament": "New Testament",
-      "chapters": 13
-    },
-    {
-      "name": "Galatians",
-      "testament": "New Testament",
-      "chapters": 6
-    },
-    {
-      "name": "Ephesians",
-      "testament": "New Testament",
-      "chapters": 6
-    },
-    {
-      "name": "Philippians",
-      "testament": "New Testament",
-      "chapters": 4
-    },
-    {
-      "name": "Colossians",
-      "testament": "New Testament",
-      "chapters": 4
-    },
-    {
-      "name": "1 Thessalonians",
-      "testament": "New Testament",
-      "chapters": 5
-    },
-    {
-      "name": "2 Thessalonians",
-      "testament": "New Testament",
-      "chapters": 3
-    },
-    {
-      "name": "1 Timothy",
-      "testament": "New Testament",
-      "chapters": 6
-    },
-    {
-      "name": "2 Timothy",
-      "testament": "New Testament",
-      "chapters": 4
-    },
-    {
-      "name": "Titus",
-      "testament": "New Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Philemon",
-      "testament": "New Testament",
-      "chapters": 1
-    },
-    {
-      "name": "Hebrews",
-      "testament": "New Testament",
-      "chapters": 13
-    },
-    {
-      "name": "James",
-      "testament": "New Testament",
-      "chapters": 5
-    },
-    {
-      "name": "1 Peter",
-      "testament": "New Testament",
-      "chapters": 5
-    },
-    {
-      "name": "2 Peter",
-      "testament": "New Testament",
-      "chapters": 3
-    },
-    {
-      "name": "1 John",
-      "testament": "New Testament",
-      "chapters": 5
-    },
-    {
-      "name": "2 John",
-      "testament": "New Testament",
-      "chapters": 1
-    },
-    {
-      "name": "3 John",
-      "testament": "New Testament",
-      "chapters": 1
-    },
-    {
-      "name": "Jude",
-      "testament": "New Testament",
-      "chapters": 1
-    },
-    {
-      "name": "Revelation",
-      "testament": "New Testament",
-      "chapters": 22
-    },
-    {
-      "name": "1 Esdras",
-      "testament": "Other",
-      "chapters": 9
-    },
-    {
-      "name": "1 Maccabees",
-      "testament": "Other",
-      "chapters": 16
-    },
-    {
-      "name": "2 Esdras",
-      "testament": "Other",
-      "chapters": 16
-    },
-    {
-      "name": "2 Maccabees",
-      "testament": "Other",
-      "chapters": 15
-    },
-    {
-      "name": "3 Maccabees",
-      "testament": "Other",
-      "chapters": 7
-    },
-    {
-      "name": "4 Maccabees",
-      "testament": "Other",
-      "chapters": 18
-    },
-    {
-      "name": "Additions to Esther",
-      "testament": "Other",
-      "chapters": 10
-    },
-    {
-      "name": "Baruch",
-      "testament": "Other",
-      "chapters": 5
-    },
-    {
-      "name": "Bel and the Dragon",
-      "testament": "Other",
-      "chapters": 1
-    },
-    {
-      "name": "Judith",
-      "testament": "Other",
-      "chapters": 16
-    },
-    {
-      "name": "Letter of Jeremiah",
-      "testament": "Other",
-      "chapters": 1
-    },
-    {
-      "name": "Prayer of Azariah",
-      "testament": "Other",
-      "chapters": 1
-    },
-    {
-      "name": "Prayer of Manasseh",
-      "testament": "Other",
-      "chapters": 1
-    },
-    {
-      "name": "Psalm 151",
-      "testament": "Other",
-      "chapters": 1
-    },
-    {
-      "name": "Sirach",
-      "testament": "Other",
-      "chapters": 51
-    },
-    {
-      "name": "Susanna",
-      "testament": "Other",
-      "chapters": 1
-    },
-    {
-      "name": "Tobit",
-      "testament": "Other",
-      "chapters": 14
-    },
-    {
-      "name": "Wisdom of Solomon",
-      "testament": "Other",
-      "chapters": 19
-    }
+    { "name": "Genesis", "testament": "Old Testament", "chapters": 50 },
+    { "name": "Exodus", "testament": "Old Testament", "chapters": 40 },
+    { "name": "Leviticus", "testament": "Old Testament", "chapters": 27 },
+    { "name": "Numbers", "testament": "Old Testament", "chapters": 36 },
+    { "name": "Deuteronomy", "testament": "Old Testament", "chapters": 34 },
+    { "name": "Joshua", "testament": "Old Testament", "chapters": 24 },
+    { "name": "Judges", "testament": "Old Testament", "chapters": 21 },
+    { "name": "Ruth", "testament": "Old Testament", "chapters": 4 },
+    { "name": "1 Samuel", "testament": "Old Testament", "chapters": 31 },
+    { "name": "2 Samuel", "testament": "Old Testament", "chapters": 24 },
+    { "name": "1 Kings", "testament": "Old Testament", "chapters": 22 },
+    { "name": "2 Kings", "testament": "Old Testament", "chapters": 25 },
+    { "name": "1 Chronicles", "testament": "Old Testament", "chapters": 29 },
+    { "name": "2 Chronicles", "testament": "Old Testament", "chapters": 36 },
+    { "name": "Ezra", "testament": "Old Testament", "chapters": 10 },
+    { "name": "Nehemiah", "testament": "Old Testament", "chapters": 13 },
+    { "name": "Esther", "testament": "Old Testament", "chapters": 10 },
+    { "name": "Job", "testament": "Old Testament", "chapters": 42 },
+    { "name": "Psalm", "testament": "Old Testament", "chapters": 150 },
+    { "name": "Proverbs", "testament": "Old Testament", "chapters": 31 },
+    { "name": "Ecclesiastes", "testament": "Old Testament", "chapters": 12 },
+    { "name": "Song of Solomon", "testament": "Old Testament", "chapters": 8 },
+    { "name": "Isaiah", "testament": "Old Testament", "chapters": 66 },
+    { "name": "Jeremiah", "testament": "Old Testament", "chapters": 52 },
+    { "name": "Lamentations", "testament": "Old Testament", "chapters": 5 },
+    { "name": "Ezekiel", "testament": "Old Testament", "chapters": 48 },
+    { "name": "Daniel", "testament": "Old Testament", "chapters": 12 },
+    { "name": "Hosea", "testament": "Old Testament", "chapters": 14 },
+    { "name": "Joel", "testament": "Old Testament", "chapters": 3 },
+    { "name": "Amos", "testament": "Old Testament", "chapters": 9 },
+    { "name": "Obadiah", "testament": "Old Testament", "chapters": 1 },
+    { "name": "Jonah", "testament": "Old Testament", "chapters": 4 },
+    { "name": "Micah", "testament": "Old Testament", "chapters": 7 },
+    { "name": "Nahum", "testament": "Old Testament", "chapters": 3 },
+    { "name": "Habakkuk", "testament": "Old Testament", "chapters": 3 },
+    { "name": "Zephaniah", "testament": "Old Testament", "chapters": 3 },
+    { "name": "Haggai", "testament": "Old Testament", "chapters": 2 },
+    { "name": "Zechariah", "testament": "Old Testament", "chapters": 14 },
+    { "name": "Malachi", "testament": "Old Testament", "chapters": 4 },
+    { "name": "1 Esdras", "testament": "Deuterocanon", "chapters": 9 },
+    { "name": "1 Maccabees", "testament": "Deuterocanon", "chapters": 16 },
+    { "name": "2 Esdras", "testament": "Deuterocanon", "chapters": 16 },
+    { "name": "2 Maccabees", "testament": "Deuterocanon", "chapters": 15 },
+    { "name": "3 Maccabees", "testament": "Deuterocanon", "chapters": 7 },
+    { "name": "4 Maccabees", "testament": "Deuterocanon", "chapters": 18 },
+    { "name": "Additions to Esther", "testament": "Deuterocanon", "chapters": 10 },
+    { "name": "Baruch", "testament": "Deuterocanon", "chapters": 5 },
+    { "name": "Bel and the Dragon", "testament": "Deuterocanon", "chapters": 1 },
+    { "name": "Judith", "testament": "Deuterocanon", "chapters": 16 },
+    { "name": "Letter of Jeremiah", "testament": "Deuterocanon", "chapters": 1 },
+    { "name": "Prayer of Azariah", "testament": "Deuterocanon", "chapters": 1 },
+    { "name": "Prayer of Manasseh", "testament": "Deuterocanon", "chapters": 1 },
+    { "name": "Psalm 151", "testament": "Deuterocanon", "chapters": 1 },
+    { "name": "Sirach", "testament": "Deuterocanon", "chapters": 51 },
+    { "name": "Susanna", "testament": "Deuterocanon", "chapters": 1 },
+    { "name": "Tobit", "testament": "Deuterocanon", "chapters": 14 },
+    { "name": "Wisdom of Solomon", "testament": "Deuterocanon", "chapters": 19 },
+    { "name": "Matthew", "testament": "New Testament", "chapters": 28 },
+    { "name": "Mark", "testament": "New Testament", "chapters": 16 },
+    { "name": "Luke", "testament": "New Testament", "chapters": 24 },
+    { "name": "John", "testament": "New Testament", "chapters": 21 },
+    { "name": "Acts", "testament": "New Testament", "chapters": 28 },
+    { "name": "Romans", "testament": "New Testament", "chapters": 16 },
+    { "name": "1 Corinthians", "testament": "New Testament", "chapters": 16 },
+    { "name": "2 Corinthians", "testament": "New Testament", "chapters": 13 },
+    { "name": "Galatians", "testament": "New Testament", "chapters": 6 },
+    { "name": "Ephesians", "testament": "New Testament", "chapters": 6 },
+    { "name": "Philippians", "testament": "New Testament", "chapters": 4 },
+    { "name": "Colossians", "testament": "New Testament", "chapters": 4 },
+    { "name": "1 Thessalonians", "testament": "New Testament", "chapters": 5 },
+    { "name": "2 Thessalonians", "testament": "New Testament", "chapters": 3 },
+    { "name": "1 Timothy", "testament": "New Testament", "chapters": 6 },
+    { "name": "2 Timothy", "testament": "New Testament", "chapters": 4 },
+    { "name": "Titus", "testament": "New Testament", "chapters": 3 },
+    { "name": "Philemon", "testament": "New Testament", "chapters": 1 },
+    { "name": "Hebrews", "testament": "New Testament", "chapters": 13 },
+    { "name": "James", "testament": "New Testament", "chapters": 5 },
+    { "name": "1 Peter", "testament": "New Testament", "chapters": 5 },
+    { "name": "2 Peter", "testament": "New Testament", "chapters": 3 },
+    { "name": "1 John", "testament": "New Testament", "chapters": 5 },
+    { "name": "2 John", "testament": "New Testament", "chapters": 1 },
+    { "name": "3 John", "testament": "New Testament", "chapters": 1 },
+    { "name": "Jude", "testament": "New Testament", "chapters": 1 },
+    { "name": "Revelation", "testament": "New Testament", "chapters": 22 }
   ]
 }

--- a/translations/WEB/meta.json
+++ b/translations/WEB/meta.json
@@ -16,405 +16,85 @@
     "copyright": "World English Bible (WEB). Public domain."
   },
   "books": [
-    {
-      "name": "Genesis",
-      "testament": "Old Testament",
-      "chapters": 50
-    },
-    {
-      "name": "Exodus",
-      "testament": "Old Testament",
-      "chapters": 40
-    },
-    {
-      "name": "Leviticus",
-      "testament": "Old Testament",
-      "chapters": 27
-    },
-    {
-      "name": "Numbers",
-      "testament": "Old Testament",
-      "chapters": 36
-    },
-    {
-      "name": "Deuteronomy",
-      "testament": "Old Testament",
-      "chapters": 34
-    },
-    {
-      "name": "Joshua",
-      "testament": "Old Testament",
-      "chapters": 24
-    },
-    {
-      "name": "Judges",
-      "testament": "Old Testament",
-      "chapters": 21
-    },
-    {
-      "name": "Ruth",
-      "testament": "Old Testament",
-      "chapters": 4
-    },
-    {
-      "name": "1 Samuel",
-      "testament": "Old Testament",
-      "chapters": 31
-    },
-    {
-      "name": "2 Samuel",
-      "testament": "Old Testament",
-      "chapters": 24
-    },
-    {
-      "name": "1 Kings",
-      "testament": "Old Testament",
-      "chapters": 22
-    },
-    {
-      "name": "2 Kings",
-      "testament": "Old Testament",
-      "chapters": 25
-    },
-    {
-      "name": "1 Chronicles",
-      "testament": "Old Testament",
-      "chapters": 29
-    },
-    {
-      "name": "2 Chronicles",
-      "testament": "Old Testament",
-      "chapters": 36
-    },
-    {
-      "name": "Ezra",
-      "testament": "Old Testament",
-      "chapters": 10
-    },
-    {
-      "name": "Nehemiah",
-      "testament": "Old Testament",
-      "chapters": 13
-    },
-    {
-      "name": "Esther",
-      "testament": "Old Testament",
-      "chapters": 10
-    },
-    {
-      "name": "Job",
-      "testament": "Old Testament",
-      "chapters": 42
-    },
-    {
-      "name": "Psalm",
-      "testament": "Old Testament",
-      "chapters": 150
-    },
-    {
-      "name": "Proverbs",
-      "testament": "Old Testament",
-      "chapters": 31
-    },
-    {
-      "name": "Ecclesiastes",
-      "testament": "Old Testament",
-      "chapters": 12
-    },
-    {
-      "name": "Song of Solomon",
-      "testament": "Old Testament",
-      "chapters": 8
-    },
-    {
-      "name": "Isaiah",
-      "testament": "Old Testament",
-      "chapters": 66
-    },
-    {
-      "name": "Jeremiah",
-      "testament": "Old Testament",
-      "chapters": 52
-    },
-    {
-      "name": "Lamentations",
-      "testament": "Old Testament",
-      "chapters": 5
-    },
-    {
-      "name": "Ezekiel",
-      "testament": "Old Testament",
-      "chapters": 48
-    },
-    {
-      "name": "Daniel",
-      "testament": "Old Testament",
-      "chapters": 12
-    },
-    {
-      "name": "Hosea",
-      "testament": "Old Testament",
-      "chapters": 14
-    },
-    {
-      "name": "Joel",
-      "testament": "Old Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Amos",
-      "testament": "Old Testament",
-      "chapters": 9
-    },
-    {
-      "name": "Obadiah",
-      "testament": "Old Testament",
-      "chapters": 1
-    },
-    {
-      "name": "Jonah",
-      "testament": "Old Testament",
-      "chapters": 4
-    },
-    {
-      "name": "Micah",
-      "testament": "Old Testament",
-      "chapters": 7
-    },
-    {
-      "name": "Nahum",
-      "testament": "Old Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Habakkuk",
-      "testament": "Old Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Zephaniah",
-      "testament": "Old Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Haggai",
-      "testament": "Old Testament",
-      "chapters": 2
-    },
-    {
-      "name": "Zechariah",
-      "testament": "Old Testament",
-      "chapters": 14
-    },
-    {
-      "name": "Malachi",
-      "testament": "Old Testament",
-      "chapters": 4
-    },
-    {
-      "name": "Matthew",
-      "testament": "New Testament",
-      "chapters": 28
-    },
-    {
-      "name": "Mark",
-      "testament": "New Testament",
-      "chapters": 16
-    },
-    {
-      "name": "Luke",
-      "testament": "New Testament",
-      "chapters": 24
-    },
-    {
-      "name": "John",
-      "testament": "New Testament",
-      "chapters": 21
-    },
-    {
-      "name": "Acts",
-      "testament": "New Testament",
-      "chapters": 28
-    },
-    {
-      "name": "Romans",
-      "testament": "New Testament",
-      "chapters": 16
-    },
-    {
-      "name": "1 Corinthians",
-      "testament": "New Testament",
-      "chapters": 16
-    },
-    {
-      "name": "2 Corinthians",
-      "testament": "New Testament",
-      "chapters": 13
-    },
-    {
-      "name": "Galatians",
-      "testament": "New Testament",
-      "chapters": 6
-    },
-    {
-      "name": "Ephesians",
-      "testament": "New Testament",
-      "chapters": 6
-    },
-    {
-      "name": "Philippians",
-      "testament": "New Testament",
-      "chapters": 4
-    },
-    {
-      "name": "Colossians",
-      "testament": "New Testament",
-      "chapters": 4
-    },
-    {
-      "name": "1 Thessalonians",
-      "testament": "New Testament",
-      "chapters": 5
-    },
-    {
-      "name": "2 Thessalonians",
-      "testament": "New Testament",
-      "chapters": 3
-    },
-    {
-      "name": "1 Timothy",
-      "testament": "New Testament",
-      "chapters": 6
-    },
-    {
-      "name": "2 Timothy",
-      "testament": "New Testament",
-      "chapters": 4
-    },
-    {
-      "name": "Titus",
-      "testament": "New Testament",
-      "chapters": 3
-    },
-    {
-      "name": "Philemon",
-      "testament": "New Testament",
-      "chapters": 1
-    },
-    {
-      "name": "Hebrews",
-      "testament": "New Testament",
-      "chapters": 13
-    },
-    {
-      "name": "James",
-      "testament": "New Testament",
-      "chapters": 5
-    },
-    {
-      "name": "1 Peter",
-      "testament": "New Testament",
-      "chapters": 5
-    },
-    {
-      "name": "2 Peter",
-      "testament": "New Testament",
-      "chapters": 3
-    },
-    {
-      "name": "1 John",
-      "testament": "New Testament",
-      "chapters": 5
-    },
-    {
-      "name": "2 John",
-      "testament": "New Testament",
-      "chapters": 1
-    },
-    {
-      "name": "3 John",
-      "testament": "New Testament",
-      "chapters": 1
-    },
-    {
-      "name": "Jude",
-      "testament": "New Testament",
-      "chapters": 1
-    },
-    {
-      "name": "Revelation",
-      "testament": "New Testament",
-      "chapters": 22
-    },
-    {
-      "name": "1 Esdras",
-      "testament": "Other",
-      "chapters": 8
-    },
-    {
-      "name": "1 Maccabees",
-      "testament": "Other",
-      "chapters": 15
-    },
-    {
-      "name": "2 Esdras",
-      "testament": "Other",
-      "chapters": 12
-    },
-    {
-      "name": "2 Maccabees",
-      "testament": "Other",
-      "chapters": 15
-    },
-    {
-      "name": "3 Maccabees",
-      "testament": "Other",
-      "chapters": 2
-    },
-    {
-      "name": "4 Maccabees",
-      "testament": "Other",
-      "chapters": 1
-    },
-    {
-      "name": "Additions to Esther",
-      "testament": "Other",
-      "chapters": 10
-    },
-    {
-      "name": "Baruch",
-      "testament": "Other",
-      "chapters": 2
-    },
-    {
-      "name": "Judith",
-      "testament": "Other",
-      "chapters": 9
-    },
-    {
-      "name": "Prayer of Manasseh",
-      "testament": "Other",
-      "chapters": 1
-    },
-    {
-      "name": "Psalm 151",
-      "testament": "Other",
-      "chapters": 1
-    },
-    {
-      "name": "Sirach",
-      "testament": "Other",
-      "chapters": 51
-    },
-    {
-      "name": "Tobit",
-      "testament": "Other",
-      "chapters": 10
-    },
-    {
-      "name": "Wisdom of Solomon",
-      "testament": "Other",
-      "chapters": 19
-    }
+    { "name": "Genesis", "testament": "Old Testament", "chapters": 50 },
+    { "name": "Exodus", "testament": "Old Testament", "chapters": 40 },
+    { "name": "Leviticus", "testament": "Old Testament", "chapters": 27 },
+    { "name": "Numbers", "testament": "Old Testament", "chapters": 36 },
+    { "name": "Deuteronomy", "testament": "Old Testament", "chapters": 34 },
+    { "name": "Joshua", "testament": "Old Testament", "chapters": 24 },
+    { "name": "Judges", "testament": "Old Testament", "chapters": 21 },
+    { "name": "Ruth", "testament": "Old Testament", "chapters": 4 },
+    { "name": "1 Samuel", "testament": "Old Testament", "chapters": 31 },
+    { "name": "2 Samuel", "testament": "Old Testament", "chapters": 24 },
+    { "name": "1 Kings", "testament": "Old Testament", "chapters": 22 },
+    { "name": "2 Kings", "testament": "Old Testament", "chapters": 25 },
+    { "name": "1 Chronicles", "testament": "Old Testament", "chapters": 29 },
+    { "name": "2 Chronicles", "testament": "Old Testament", "chapters": 36 },
+    { "name": "Ezra", "testament": "Old Testament", "chapters": 10 },
+    { "name": "Nehemiah", "testament": "Old Testament", "chapters": 13 },
+    { "name": "Esther", "testament": "Old Testament", "chapters": 10 },
+    { "name": "Job", "testament": "Old Testament", "chapters": 42 },
+    { "name": "Psalm", "testament": "Old Testament", "chapters": 150 },
+    { "name": "Proverbs", "testament": "Old Testament", "chapters": 31 },
+    { "name": "Ecclesiastes", "testament": "Old Testament", "chapters": 12 },
+    { "name": "Song of Solomon", "testament": "Old Testament", "chapters": 8 },
+    { "name": "Isaiah", "testament": "Old Testament", "chapters": 66 },
+    { "name": "Jeremiah", "testament": "Old Testament", "chapters": 52 },
+    { "name": "Lamentations", "testament": "Old Testament", "chapters": 5 },
+    { "name": "Ezekiel", "testament": "Old Testament", "chapters": 48 },
+    { "name": "Daniel", "testament": "Old Testament", "chapters": 12 },
+    { "name": "Hosea", "testament": "Old Testament", "chapters": 14 },
+    { "name": "Joel", "testament": "Old Testament", "chapters": 3 },
+    { "name": "Amos", "testament": "Old Testament", "chapters": 9 },
+    { "name": "Obadiah", "testament": "Old Testament", "chapters": 1 },
+    { "name": "Jonah", "testament": "Old Testament", "chapters": 4 },
+    { "name": "Micah", "testament": "Old Testament", "chapters": 7 },
+    { "name": "Nahum", "testament": "Old Testament", "chapters": 3 },
+    { "name": "Habakkuk", "testament": "Old Testament", "chapters": 3 },
+    { "name": "Zephaniah", "testament": "Old Testament", "chapters": 3 },
+    { "name": "Haggai", "testament": "Old Testament", "chapters": 2 },
+    { "name": "Zechariah", "testament": "Old Testament", "chapters": 14 },
+    { "name": "Malachi", "testament": "Old Testament", "chapters": 4 },
+    { "name": "1 Esdras", "testament": "Deuterocanon", "chapters": 8 },
+    { "name": "1 Maccabees", "testament": "Deuterocanon", "chapters": 15 },
+    { "name": "2 Esdras", "testament": "Deuterocanon", "chapters": 12 },
+    { "name": "2 Maccabees", "testament": "Deuterocanon", "chapters": 15 },
+    { "name": "3 Maccabees", "testament": "Deuterocanon", "chapters": 2 },
+    { "name": "4 Maccabees", "testament": "Deuterocanon", "chapters": 1 },
+    { "name": "Additions to Esther", "testament": "Deuterocanon", "chapters": 10 },
+    { "name": "Baruch", "testament": "Deuterocanon", "chapters": 2 },
+    { "name": "Judith", "testament": "Deuterocanon", "chapters": 9 },
+    { "name": "Prayer of Manasseh", "testament": "Deuterocanon", "chapters": 1 },
+    { "name": "Psalm 151", "testament": "Deuterocanon", "chapters": 1 },
+    { "name": "Sirach", "testament": "Deuterocanon", "chapters": 51 },
+    { "name": "Tobit", "testament": "Deuterocanon", "chapters": 10 },
+    { "name": "Wisdom of Solomon", "testament": "Deuterocanon", "chapters": 19 },
+    { "name": "Matthew", "testament": "New Testament", "chapters": 28 },
+    { "name": "Mark", "testament": "New Testament", "chapters": 16 },
+    { "name": "Luke", "testament": "New Testament", "chapters": 24 },
+    { "name": "John", "testament": "New Testament", "chapters": 21 },
+    { "name": "Acts", "testament": "New Testament", "chapters": 28 },
+    { "name": "Romans", "testament": "New Testament", "chapters": 16 },
+    { "name": "1 Corinthians", "testament": "New Testament", "chapters": 16 },
+    { "name": "2 Corinthians", "testament": "New Testament", "chapters": 13 },
+    { "name": "Galatians", "testament": "New Testament", "chapters": 6 },
+    { "name": "Ephesians", "testament": "New Testament", "chapters": 6 },
+    { "name": "Philippians", "testament": "New Testament", "chapters": 4 },
+    { "name": "Colossians", "testament": "New Testament", "chapters": 4 },
+    { "name": "1 Thessalonians", "testament": "New Testament", "chapters": 5 },
+    { "name": "2 Thessalonians", "testament": "New Testament", "chapters": 3 },
+    { "name": "1 Timothy", "testament": "New Testament", "chapters": 6 },
+    { "name": "2 Timothy", "testament": "New Testament", "chapters": 4 },
+    { "name": "Titus", "testament": "New Testament", "chapters": 3 },
+    { "name": "Philemon", "testament": "New Testament", "chapters": 1 },
+    { "name": "Hebrews", "testament": "New Testament", "chapters": 13 },
+    { "name": "James", "testament": "New Testament", "chapters": 5 },
+    { "name": "1 Peter", "testament": "New Testament", "chapters": 5 },
+    { "name": "2 Peter", "testament": "New Testament", "chapters": 3 },
+    { "name": "1 John", "testament": "New Testament", "chapters": 5 },
+    { "name": "2 John", "testament": "New Testament", "chapters": 1 },
+    { "name": "3 John", "testament": "New Testament", "chapters": 1 },
+    { "name": "Jude", "testament": "New Testament", "chapters": 1 },
+    { "name": "Revelation", "testament": "New Testament", "chapters": 22 }
   ]
 }

--- a/ui.js
+++ b/ui.js
@@ -132,32 +132,44 @@ export function cacheElements(app) {
 }
 
 // Load theme on app start (uses localStorage as initial fallback)
-export function loadTheme(app) {
-	let savedLightMode = false;
-	try { savedLightMode = localStorage.getItem('lightMode') === 'true'; } catch (_) {}
-	if (savedLightMode) {
-		document.documentElement.classList.add('light-mode');
-		document.body.classList.add('light-mode');
-	}
-	updateThemeIcon(savedLightMode);
+export function loadTheme() {
+	let mode = 'system';
+	try {
+		const raw = localStorage.getItem('lightMode');
+		// migrate old boolean strings
+		if (raw === 'true')  mode = 'light';
+		else if (raw === 'false') mode = 'dark';
+		else if (raw === 'light' || raw === 'dark' || raw === 'system') mode = raw;
+	} catch (_) {}
+	applyLightMode(mode);
 }
 
-// Toggle between light and dark mode
-export async function toggleTheme(app) {
-	document.documentElement.classList.toggle('light-mode');
-	document.body.classList.toggle('light-mode');
 
-	const isLightMode = document.body.classList.contains('light-mode');
+export function resolveLightMode(mode) {
+	if (mode === 'light') return true;
+	if (mode === 'dark')  return false;
+	return window.matchMedia('(prefers-color-scheme: light)').matches;
+}
 
-	// Always write locally so cold loads get the correct value immediately.
-	try { localStorage.setItem('lightMode', isLightMode); } catch (_) {}
+export function applyLightMode(mode) {
+	const isLight = resolveLightMode(mode);
+	document.documentElement.classList.toggle('light-mode', isLight);
+	document.body.classList.toggle('light-mode', isLight);
+	updateThemeIcon(isLight);
+}
 
+export async function setLightMode(app, mode) {
+	const normalized = mode === 'light' || mode === 'dark' || mode === 'system' ? mode : 'system';
+	app.state.lightMode = normalized;
+	try { localStorage.setItem('lightMode', normalized); } catch (_) {}
+	applyLightMode(normalized);
+	const sel = document.getElementById('lightModeSelect');
+	if (sel) sel.value = normalized;
 	if (app.currentUser) {
-		await app.database.ref(`users/${app.currentUser.uid}/settings/lightMode`).set(isLightMode);
+		await app.database.ref(`users/${app.currentUser.uid}/settings/lightMode`).set(normalized);
 	}
-
-	updateThemeIcon(isLightMode);
 }
+
 
 // Update theme icon based on current mode
 export function updateThemeIcon(isLightMode) {


### PR DESCRIPTION
## What

Bug fixes, a UI polish pass, and a light mode system overhaul.

## Fixes

- **Verse number toggle** no longer calls `applySettings` on each toggle, preventing `changeColorTheme` from clobbering the active theme with a stale `app.state.colorTheme`.
- **`bibleBooks`** is now rebuilt from meta on initial load, not only on translation change — fixes missing books on first render.
- **Footnotes / cross-references** sections moved inside `passage-container` so they scroll with the passage.
- **`deuterocanonInfoModal`** added to backdrop-click and Esc close handlers.
- **Selected-verse glow** constrained with `box-sizing: border-box`, `max-width: 100%`, and `overflow: hidden` to prevent the highlight from overflowing on narrow viewports (iOS Safari).
- **Firebase `lightMode`** boolean migrated to string on restore; string written on signup to avoid future type mismatch.
- **User menu modal** width capped at 360px; Sign Out button no longer stretches full width; Change Email and Change Password buttons placed in a row.
- **`toggleTheme` import** removed; `applyLightMode` import added in `app.js`.

## Features

- **3-way Appearance select** (system / light / dark) replaces the light mode checkbox. Adds `resolveLightMode`, `applyLightMode`, `setLightMode`; `loadTheme` migrated to string mode. `lightModeSelect` wired to `setLightMode` with a `matchMedia` system listener.

## Content

- **Deuterocanon info modal** content rewritten for clarity and completeness; modal heading renamed to Apocrypha.
- **"Other" testament** renamed to "Deuterocanon" in NRSVUE and WEB `meta.json`.
- Reformers' views heading updated for clarity.