### PR TITLE
exp → dev: .hidden fix, badge colors, copyright cleanup

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -40,8 +40,14 @@ jobs:
           SHA="${GITHUB_SHA::7}"
           SHA4="${GITHUB_SHA: -4}"
           INFO="${BRANCH^^} ${SHA4^^}"
+          case "${BRANCH}" in
+            dev)  BUILD_COLOR="#09752b" ;;
+            exp)  BUILD_COLOR="#790606" ;;
+            *)    BUILD_COLOR="#444444" ;;
+          esac
           echo "Injecting: $INFO"
           sed -i "s|__BUILD_INFO__|${INFO}|g" index.html
+          sed -i "s|__BUILD_COLOR__|${BUILD_COLOR}|g" css/pericope.css
           sed -i "s/__BUILD_ID__/$GITHUB_SHA/g" sw.js index.html
           sed -i "s|\(<script[^>]* src=\"\)\([^?\"]*\)\(\.js\)\(\"\)|\1\2\3?v=${GITHUB_SHA}\4|g" index.html
           echo "$GITHUB_SHA" > version.txt

--- a/css/pericope.css
+++ b/css/pericope.css
@@ -152,7 +152,7 @@
     letter-spacing: 0.04em;
     text-transform: uppercase;
     color: #ffffff;
-    background: #790606;
+    background: __BUILD_COLOR__;
     padding: 0.15rem 0.45rem;
     border-radius: 4px;
     vertical-align: middle;

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -121,6 +121,8 @@
    11. UTILITY CLASSES
    ================================ */
 
+.hidden { display: none !important; }
+
 /* Hide verse numbers when setting is off */
 body.hide-verse-numbers .passage-text .verse-num {
     display: none !important;
@@ -189,5 +191,4 @@ body.font-opendyslexic3 .search-result-content {
         border: none;
     }
 }
-
 


### PR DESCRIPTION
## Summary

Three housekeeping changes made on `exp` since the last merge.

---

### 🐛 Fix: `.hidden` utility class missing (`css/utilities.css`)

The `#footnotesSection` and `#crossReferencesSection` elements in `index.html` both carry `class="hidden"` by default, but `.hidden` was never defined in any stylesheet — so the headings "Footnotes" and "Cross-References" were always visible at the bottom of the passage text regardless of settings.

Added the missing rule to the top of Section 11 in `utilities.css`:

```css
.hidden { display: none !important; }
```

---

### 🎨 Build badge: branch-specific colors

The deploy workflow now injects a per-branch background color via a `__BUILD_COLOR__` placeholder in `pericope.css`.

| Branch | Color |
|---|---|
| `exp` | `#790606` (red) |
| `dev` | `#09752b` (green) |
| other | `#444444` (gray) |

---

### 🧹 Clean up footer

Removed the string `" Verify distribution rights before publishing."` from the `copyright` field in all translation metadata files (17 instances across `info.json`, `meta.json`, and `translations/index.json` for ESV, NIV, NLT, CSB, NRSVUE, NKJV, MEV, and ISV).

---

## Testing

- [ ] Footnotes and cross-references headings no longer appear unless the toggles are enabled in settings
- [ ] Deploy to `dev` shows green badge (`DEV XXXX`)
- [ ] Translation copyright strings no longer include the removed phrase