### PR TITLE
Theme system overhaul, smooth color transitions, and refresh/flash fixes

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -32,4 +32,33 @@ body.modal-open {
     overflow: hidden;
 }
 
+/* ================================
+   COLOR TRANSITIONS
+   Smooth 300ms ease on background-color, color, and border-color for all
+   elements so theme and light/dark mode switches animate rather than snap.
 
+   body.no-color-transition suppresses this during initial page load
+   (guard applied before first paint, removed on DOMContentLoaded) so
+   users never see a color flash on cold load.
+
+   prefers-reduced-motion zeroes all durations per WCAG 2.3.
+   ================================ */
+
+body:not(.no-color-transition) *,
+body:not(.no-color-transition) *::before,
+body:not(.no-color-transition) *::after {
+    transition:
+        background-color 300ms ease,
+        color            300ms ease,
+        border-color     300ms ease,
+        fill             300ms ease,
+        stroke           300ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    body:not(.no-color-transition) *,
+    body:not(.no-color-transition) *::before,
+    body:not(.no-color-transition) *::after {
+        transition-duration: 0.01ms !important;
+    }
+}

--- a/css/layout.css
+++ b/css/layout.css
@@ -104,9 +104,9 @@ body.chrome-no-transition .top-chrome {
 
 /* Dracula dark: logo uses orange (--dracula-orange) instead of purple.
    Dracula dark = no theme class + no .light-mode. */
-:root:not(.onyx-theme):not(.sage-theme):not(.ember-theme):not(.perplexity-theme):not(.light-mode) .logo,
-html:not(.onyx-theme):not(.sage-theme):not(.ember-theme):not(.perplexity-theme):not(.light-mode) .logo,
-body:not(.onyx-theme):not(.sage-theme):not(.ember-theme):not(.perplexity-theme):not(.light-mode) .logo {
+:root:not(.onyx-theme):not(.sage-theme):not(.ember-theme):not(.perplexity-theme):not(.geek-theme):not(.light-mode) .logo,
+html:not(.onyx-theme):not(.sage-theme):not(.ember-theme):not(.perplexity-theme):not(.geek-theme):not(.light-mode) .logo,
+body:not(.onyx-theme):not(.sage-theme):not(.ember-theme):not(.perplexity-theme):not(.geek-theme):not(.light-mode) .logo {
     color: var(--dracula-orange);
 }
 

--- a/css/themes.css
+++ b/css/themes.css
@@ -33,12 +33,43 @@ body.light-mode {
     --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.15);
 }
 
-/* Alucard — official Dracula light mode (https://spec.draculatheme.com)
-   Targets Dracula (default theme, no theme class) in light mode only.
-   Higher specificity than the generic .light-mode block above. */
-:root.light-mode:not(.onyx-theme):not(.sage-theme):not(.ember-theme):not(.perplexity-theme):not(.basic-theme):not(.geek-theme),
-html.light-mode:not(.onyx-theme):not(.sage-theme):not(.ember-theme):not(.perplexity-theme):not(.basic-theme):not(.geek-theme),
-body.light-mode:not(.onyx-theme):not(.sage-theme):not(.ember-theme):not(.perplexity-theme):not(.basic-theme):not(.geek-theme) {
+/* Dracula — explicit selectors so Dracula can be chosen intentionally.
+   Values mirror the previous :root defaults from tokens.css. */
+:root.dracula-theme,
+html.dracula-theme,
+body.dracula-theme {
+    --bg-base: var(--dracula-bg-darker);
+    --bg-card: var(--dracula-bg-dark);
+    --bg-raised: var(--dracula-bg);
+
+    --text-heading: var(--dracula-fg);
+    --text-body: var(--dracula-comment);
+    --text-muted-2: var(--dracula-comment);
+
+    --border-neutral: var(--dracula-current-line);
+    --highlight-border: color-mix(in srgb, var(--border-neutral) 60%, white);
+
+    --primary-color: var(--dracula-purple);
+    --primary-dark: hsl(265, 89%, 64%);
+    --primary-light: var(--dracula-pink);
+    --secondary-color: var(--dracula-orange);
+    --accent-color: var(--dracula-cyan);
+
+    --success-color: var(--dracula-green);
+    --warning-color: var(--dracula-yellow);
+    --error-color: var(--dracula-red);
+
+    --footnote-hover-bg: color-mix(in srgb, var(--primary-color) 18%, transparent);
+
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.5);
+    --shadow-md: 0 6px 16px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.55);
+}
+
+/* Alucard — official Dracula light mode (https://spec.draculatheme.com) */
+:root.dracula-theme.light-mode,
+html.dracula-theme.light-mode,
+body.dracula-theme.light-mode {
     --bg-base:    var(--alucard-bg);
     --bg-card:    var(--alucard-bg-lighter);
     --bg-raised:  var(--alucard-bg-light);
@@ -138,9 +169,6 @@ body.onyx-theme.light-mode {
 
 /* ================================
    Sage theme — forest green; organic, calm reading
-   Primary hue: 145° green. No overlap with any other theme (nearest is
-   Perplexity at 187° teal — 42° apart). Surfaces: deep forest dark /
-   warm sage-tinted light.
    ================================ */
 :root.sage-theme,
 html.sage-theme,
@@ -205,10 +233,7 @@ body.sage-theme.light-mode {
 }
 
 /* ================================
-   Ember theme — candlelit warmth; analogous warm palette
-   Primary hue: 35° amber. Secondary: 8° rust-red. Accent: 50° gold.
-   All three hues within 45° of each other — fully analogous, zero
-   cool colors. Surfaces: dark chocolate / warm cream.
+   Ember theme — candlelit warmth
    ================================ */
 :root.ember-theme,
 html.ember-theme,
@@ -364,8 +389,6 @@ body.perplexity-theme.light-mode {
    Basic theme — pure achromatic; zero hue, maximum contrast
    Dark mode: pure white text on pure black.
    Light mode: pure black text on pure white.
-   No accent color — links and interactive elements use black/white
-   with an underline or border instead of color.
    ================================ */
 :root.basic-theme,
 html.basic-theme,
@@ -447,7 +470,6 @@ body.basic-theme.light-mode .passage-container {
 /* ================================
    The Geek Shall Inherit The Earth
    Classic terminal: #00AA00 green on pure black.
-   Geek theme changes color only; reading font remains whatever is already active.
    Light mode toggle is intentionally ignored; this theme is always dark.
    ================================ */
 :root.geek-theme,
@@ -490,17 +512,30 @@ body.geek-theme .passage-container {
     box-shadow: none;
 }
 
-/* Beat components.css specificity for passage text color.
-   Geek theme should change color only and leave the active reading font alone. */
+/* Beat components.css specificity for passage text color. */
+:root.geek-theme .passage-text,
+html.geek-theme .passage-text,
 body.geek-theme .passage-text,
+:root.geek-theme .passage,
+html.geek-theme .passage,
 body.geek-theme .passage,
+:root.geek-theme .passage-text h2,
+html.geek-theme .passage-text h2,
 body.geek-theme .passage-text h2,
+:root.geek-theme .passage-text h3,
+html.geek-theme .passage-text h3,
 body.geek-theme .passage-text h3,
+:root.geek-theme .passage-text h4,
+html.geek-theme .passage-text h4,
 body.geek-theme .passage-text h4,
+:root.geek-theme .passage-title,
+html.geek-theme .passage-title,
 body.geek-theme .passage-title {
     color: #00AA00 !important;
 }
 
+:root.geek-theme .verse-num,
+html.geek-theme .verse-num,
 body.geek-theme .verse-num {
     color: #007700 !important;
 }

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -81,37 +81,38 @@
 
     /* ================================
        Semantic tokens (canonical)
-       Default = Dracula Dark
+       Default = Basic (black & white)
+       Theme overrides in themes.css.
        ================================ */
 
     /* Surfaces */
-    --bg-base: var(--dracula-bg-darker);
-    --bg-card: var(--dracula-bg-dark);
-    --bg-raised: var(--dracula-bg);
+    --bg-base: hsl(0, 0%, 0%);
+    --bg-card: hsl(0, 0%, 4%);
+    --bg-raised: hsl(0, 0%, 9%);
 
     /* Text */
-    --text-heading: var(--dracula-fg);
-    --text-body: var(--dracula-comment);
-    --text-muted-2: var(--dracula-comment);
+    --text-heading: hsl(0, 0%, 100%);
+    --text-body: hsl(0, 0%, 100%);
+    --text-muted-2: hsl(0, 0%, 65%);
 
     /* Borders */
-    --border-neutral: var(--dracula-current-line);
-    --highlight-border: color-mix(in srgb, var(--border-neutral) 60%, white);
+    --border-neutral: hsl(0, 0%, 20%);
+    --highlight-border: hsl(0, 0%, 30%);
 
     /* Brand */
-    --primary-color: var(--dracula-purple);
-    --primary-dark: hsl(265, 89%, 64%);
-    --primary-light: var(--dracula-pink);
-    --secondary-color: var(--dracula-orange);
-    --accent-color: var(--dracula-cyan);
+    --primary-color: hsl(0, 0%, 90%);
+    --primary-dark: hsl(0, 0%, 75%);
+    --primary-light: hsl(0, 0%, 100%);
+    --secondary-color: hsl(0, 0%, 80%);
+    --accent-color: hsl(0, 0%, 85%);
 
     /* Functional */
-    --success-color: var(--dracula-green);
-    --warning-color: var(--dracula-yellow);
-    --error-color: var(--dracula-red);
+    --success-color: hsl(0, 0%, 80%);
+    --warning-color: hsl(0, 0%, 80%);
+    --error-color: hsl(0, 0%, 80%);
 
     /* Component tokens */
-    --footnote-hover-bg: color-mix(in srgb, var(--primary-color) 18%, transparent);
+    --footnote-hover-bg: rgba(255, 255, 255, 0.10);
 
     /* ================================
        Legacy aliases (existing component contract)
@@ -128,6 +129,3 @@
 
     --border-color: var(--border-neutral);
 }
-
-
-

--- a/index.html
+++ b/index.html
@@ -13,6 +13,31 @@
 	<meta name="twitter:title" content="Lege Lux" />
 	<meta name="twitter:description" content="A fast, offline-capable Bible reader with multiple translations, themes, font options, and cross-reference tools — built for focused reading." />
 	<meta name="build-id" content="__BUILD_ID__" />
+	<!-- Synchronous theme bootstrap: must run before any CSS is applied.
+	     Stamps the color-theme class and no-color-transition onto <body>
+	     before the browser paints, preventing a Dracula-flash on cold load.
+	     ES modules are deferred and cannot achieve this. -->
+	<script>
+		(function () {
+			var theme = 'basic';
+			try { theme = localStorage.getItem('colorTheme') || 'basic'; } catch (_) {}
+			var valid = { dracula: 1, onyx: 1, sage: 1, ember: 1, perplexity: 1, basic: 1, geek: 1 };
+			if (!valid[theme]) theme = 'basic';
+			document.body.classList.add(theme + '-theme', 'no-color-transition');
+
+			var mode = 'system';
+			try {
+				var raw = localStorage.getItem('lightMode');
+				if (raw === 'true' || raw === 'light')       mode = 'light';
+				else if (raw === 'false' || raw === 'dark') mode = 'dark';
+			} catch (_) {}
+			var isLight = mode === 'light' || (mode === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);
+			if (isLight) {
+				document.documentElement.classList.add('light-mode');
+				document.body.classList.add('light-mode');
+			}
+		}());
+	</script>
 	<link rel="manifest" href="./site.webmanifest" />
 	<link rel="apple-touch-icon" href="./apple-touch-icon.png" />
 	<link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png" />

--- a/index.html
+++ b/index.html
@@ -547,7 +547,7 @@
 						<input type="password" id="signupPassword" class="input-field"
 							placeholder="At least 6 characters" autocomplete="new-password" required />
 					</div>
-					<button type="submit" class="primary-btn" style="width: 100%">Create Account</button>
+					<button type="submit" id="signupSubmit" class="primary-btn" style="width: 100%">Create Account</button>
 				</form>
 				<p class="auth-switch">
 					Already have an account?

--- a/index.html
+++ b/index.html
@@ -14,16 +14,19 @@
 	<meta name="twitter:description" content="A fast, offline-capable Bible reader with multiple translations, themes, font options, and cross-reference tools — built for focused reading." />
 	<meta name="build-id" content="__BUILD_ID__" />
 	<!-- Synchronous theme bootstrap: must run before any CSS is applied.
-	     Stamps the color-theme class and no-color-transition onto <body>
-	     before the browser paints, preventing a Dracula-flash on cold load.
+	     Stamps the color-theme class and no-color-transition onto <html>
+	     (document.documentElement — always available in <head>) before the
+	     browser paints, preventing a Dracula-flash on cold load.
+	     document.body is null at this point; do NOT use it here.
 	     ES modules are deferred and cannot achieve this. -->
 	<script>
 		(function () {
+			var el = document.documentElement;
 			var theme = 'basic';
 			try { theme = localStorage.getItem('colorTheme') || 'basic'; } catch (_) {}
 			var valid = { dracula: 1, onyx: 1, sage: 1, ember: 1, perplexity: 1, basic: 1, geek: 1 };
 			if (!valid[theme]) theme = 'basic';
-			document.body.classList.add(theme + '-theme', 'no-color-transition');
+			el.classList.add(theme + '-theme', 'no-color-transition');
 
 			var mode = 'system';
 			try {
@@ -32,10 +35,7 @@
 				else if (raw === 'false' || raw === 'dark') mode = 'dark';
 			} catch (_) {}
 			var isLight = mode === 'light' || (mode === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);
-			if (isLight) {
-				document.documentElement.classList.add('light-mode');
-				document.body.classList.add('light-mode');
-			}
+			if (isLight) el.classList.add('light-mode');
 		}());
 	</script>
 	<link rel="manifest" href="./site.webmanifest" />

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -633,7 +633,7 @@ test('auth: signup with short password shows validation toast', async ({ page })
         // Navigate to signup modal — open login first, then switch.
         await page.locator('#userBtn').click();
         await expect(page.locator('#loginModal')).toBeVisible();
-        await page.locator('#showSignup').click();
+        await page.locator('#showSignupLink').click();
         await expect(page.locator('#signupModal')).toBeVisible();
 
         await page.locator('#signupEmail').fill('test@example.com');

--- a/ui.js
+++ b/ui.js
@@ -28,13 +28,17 @@ const REQUIRED_IDS = [
 	'translationModal', 'closeTranslationModal', 'translationList',
 ];
 
-// no-color-transition guard is applied synchronously by the inline <script>
-// in index.html <head> before first paint. It is removed here, after the
-// module evaluates and all initial theme/light-mode classes are in place.
-// One rAF ensures the browser has committed those classes before transitions
-// are re-enabled, so there is no flash on warm or cold load.
+// The inline <script> in <head> stamps the theme class and no-color-transition
+// onto document.documentElement before first paint (document.body is null then).
+// Once DOMContentLoaded fires, body is available — mirror all classes from
+// <html> to <body> so component CSS targeting body.X-theme continues to work,
+// then lift the transition guard from both elements.
 document.addEventListener('DOMContentLoaded', () => {
+	const htmlClasses = [...document.documentElement.classList];
+	if (htmlClasses.length) document.body.classList.add(...htmlClasses);
+
 	requestAnimationFrame(() => {
+		document.documentElement.classList.remove('no-color-transition');
 		document.body.classList.remove('no-color-transition');
 	});
 }, { once: true });
@@ -219,24 +223,27 @@ export function updateThemeIcon(isLightMode) {
 	}
 }
 
+const ALL_THEME_CLASSES = ['dracula-theme', 'onyx-theme', 'sage-theme', 'ember-theme', 'perplexity-theme', 'basic-theme', 'geek-theme'];
+
 export async function changeColorTheme(app, theme) {
-	document.body.classList.remove('dracula-theme', 'onyx-theme', 'sage-theme', 'ember-theme', 'perplexity-theme', 'basic-theme', 'geek-theme');
+	// Sync removal and addition on both <html> and <body> so that
+	// both the :root/:html CSS variable selectors and the body.X-theme
+	// component selectors (header, modals, geek overrides) resolve correctly.
+	document.documentElement.classList.remove(...ALL_THEME_CLASSES);
+	document.body.classList.remove(...ALL_THEME_CLASSES);
 
-	if (theme === 'dracula')         document.body.classList.add('dracula-theme');
-	else if (theme === 'onyx')       document.body.classList.add('onyx-theme');
-	else if (theme === 'sage')       document.body.classList.add('sage-theme');
-	else if (theme === 'ember')      document.body.classList.add('ember-theme');
-	else if (theme === 'perplexity') document.body.classList.add('perplexity-theme');
-	else if (theme === 'basic')      document.body.classList.add('basic-theme');
-	else if (theme === 'geek')       document.body.classList.add('geek-theme');
-	else { theme = 'basic'; document.body.classList.add('basic-theme'); }
+	const valid = ALL_THEME_CLASSES.includes(theme + '-theme');
+	const resolved = valid ? theme : 'basic';
+	const cls = resolved + '-theme';
 
-	// Always write locally so cold loads get the correct value immediately.
-	try { localStorage.setItem('colorTheme', theme); } catch (_) {}
+	document.documentElement.classList.add(cls);
+	document.body.classList.add(cls);
+
+	try { localStorage.setItem('colorTheme', resolved); } catch (_) {}
 
 	if (app.currentUser) {
 		await app.database
 			.ref(`users/${app.currentUser.uid}/settings/colorTheme`)
-			.set(theme);
+			.set(resolved);
 	}
 }

--- a/ui.js
+++ b/ui.js
@@ -28,6 +28,16 @@ const REQUIRED_IDS = [
 	'translationModal', 'closeTranslationModal', 'translationList',
 ];
 
+// Suppress color transitions on initial load so the first paint has no flash.
+// The class is added before DOM ready (synchronous) and removed after.
+document.body.classList.add('no-color-transition');
+document.addEventListener('DOMContentLoaded', () => {
+	// One rAF so the browser has committed the first paint before we re-enable.
+	requestAnimationFrame(() => {
+		document.body.classList.remove('no-color-transition');
+	});
+}, { once: true });
+
 export function cacheElements(app) {
 	// Validate all required IDs exist — warns immediately if HTML is stale or mismatched
 	const missing = REQUIRED_IDS.filter(id => !document.getElementById(id));

--- a/ui.js
+++ b/ui.js
@@ -28,11 +28,12 @@ const REQUIRED_IDS = [
 	'translationModal', 'closeTranslationModal', 'translationList',
 ];
 
-// Suppress color transitions on initial load so the first paint has no flash.
-// The class is added before DOM ready (synchronous) and removed after.
-document.body.classList.add('no-color-transition');
+// no-color-transition guard is applied synchronously by the inline <script>
+// in index.html <head> before first paint. It is removed here, after the
+// module evaluates and all initial theme/light-mode classes are in place.
+// One rAF ensures the browser has committed those classes before transitions
+// are re-enabled, so there is no flash on warm or cold load.
 document.addEventListener('DOMContentLoaded', () => {
-	// One rAF so the browser has committed the first paint before we re-enable.
 	requestAnimationFrame(() => {
 		document.body.classList.remove('no-color-transition');
 	});


### PR DESCRIPTION
## Overview

This PR consolidates a session of theme system fixes and UX polish — including a major rework of how theme classes are applied, significant progress on the cold-load flash and refresh detection issues, and smooth animated transitions for all color changes.

---

## Theme system overhaul

### Basic is now the unclassed default
The `:root` semantic tokens in `tokens.css` now match the Basic (black/white achromatic) theme. Any document without a theme class renders as Basic, not Dracula. Dracula's values have been moved to their own explicit selector block.

### Dracula selector fixed
`themes.css` now has a proper `:root.dracula-theme, html.dracula-theme, body.dracula-theme {}` block with all Dracula values. Previously these were baked into `:root`, so Dracula was always-on and couldn't be toggled. Alucard (Dracula light mode) is simplified to `.dracula-theme.light-mode` — no longer depends on a fragile `:not()` fallback chain.

### `<html>` and `<body>` always in sync
`changeColorTheme()` in `ui.js` now removes and adds the theme class on **both** `document.documentElement` and `document.body` on every call. On `DOMContentLoaded`, all classes are copied from `<html>` → `<body>` to bridge the gap left by the inline head script (which runs before `<body>` exists). This ensures CSS variable selectors (`html.X-theme`) and component selectors (`body.X-theme`, used by modal/chrome CSS) always agree.

### Geek theme text overrides extended
Geek theme text color overrides are now on `:root.geek-theme`, `html.geek-theme`, and `body.geek-theme` — previously `body` only, which lost to component specificity in some cases.

---

## Smooth color transitions

All color-related CSS properties now animate at 300ms ease across the entire document:

```css
transition: background-color 300ms ease, color 300ms ease,
            border-color 300ms ease, fill 300ms ease, stroke 300ms ease;
```

`fill` and `stroke` are included so SVG icons (which inherit via `currentColor`) animate alongside text. A `.no-color-transition` guard class is stamped synchronously on `<html>` before first paint and removed on `DOMContentLoaded` inside a `requestAnimationFrame`, so the initial theme load never animates. Respects `prefers-reduced-motion`.

---

## Refresh / cold-load flash progress

### Theme flash eliminated
The inline `<script>` in `<head>` now stamps the saved `colorTheme` class and `no-color-transition` onto `document.documentElement` synchronously — before the browser paints a single pixel. ES modules are always deferred and cannot achieve this. The flash is gone on cold loads.

### Loading spinner on cache miss fixed
`revealApp()` in `app.js` was previously called *before* `loadPassage()` resolved on cache-miss paths, so the app was revealed into a "Loading passage..." spinner on every cold miss. `revealApp()` is now called after `loadPassage()` settles, so the app is revealed with real content already in place.

### `document.body` null fix
The inline head script previously targeted `document.body`, which is `null` when a `<script>` runs in `<head>` — making the theme stamp a silent no-op. Switched to `document.documentElement` (always available). `themes.css` already had `html.*` selectors alongside `body.*`, so no CSS changes were needed for this.

### BUILD_ID and SW cache correlation
`__BUILD_ID__` is now the first 7 characters of the commit SHA (matching GitHub's short SHA display), making `buildId` values in debug logs directly matchable against the commit list. The build badge no longer includes a redundant branch prefix.

---

## Other fixes

- **Swipe panel drag cleanup** — `_cleanupDrag()` is now called on the early-exit path of `touchend` when `_tracking` was true at bail time, preventing the panel from floating free after a veto-race condition.
- **Selector width stability** — `#currentChapter` and `#currentVerse` use `min-width: 3ch` and `tabular-nums` so nav buttons never resize as chapter/verse numbers change digit count.
- **Auth smoke tests** — login, logout, signup validation, and reading position sync covered.
- **Short SHA in build badge** — EXP badge is red, DEV is green, others grey.
