### PR TITLE
Improve mobile navigation, modal interactions, and reading settings

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -16,6 +16,7 @@ html {
     scrollbar-width: none;
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;
+    touch-action: manipulation;
 }
 
 html::-webkit-scrollbar {
@@ -24,6 +25,7 @@ html::-webkit-scrollbar {
 
 body {
     overflow: visible;
+    touch-action: manipulation;
 }
 
 /* Lock scrolling while a modal is open.
@@ -73,7 +75,8 @@ body:not(.no-color-transition) *::after {
 /* During an active swipe drag the three panel elements must track the finger
    with zero latency. The wildcard transition above would otherwise ease every
    translateX write, causing jitter and preventing adjacent panels from sitting
-   at their correct off-screen positions when the drag begins.\n   .swiping is added to #swipeViewport the moment a horizontal drag is
+   at their correct off-screen positions when the drag begins.
+   .swiping is added to #swipeViewport the moment a horizontal drag is
    confirmed and removed when the gesture ends (cancel or commit). */
 #swipeViewport.swiping #passageText,
 #swipeViewport.swiping #swipePrev,

--- a/css/interactions.css
+++ b/css/interactions.css
@@ -118,15 +118,15 @@ body.light-mode .verse-tools-tray {
 /* ── Tool action rows ── */
 
 .verse-tools-actions {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     align-items: center;
-    justify-content: space-around;
+    justify-items: center;
     padding: 10px 0 12px;
     gap: 4px;
 }
 
 .verse-tools-actions--top {
-    justify-content: flex-start;
     padding-bottom: 6px;
     border-bottom: 1px solid rgba(255, 215, 0, 0.1);
     margin-bottom: 2px;
@@ -237,5 +237,3 @@ body.light-mode .verse-tool-letter {
     50% { box-shadow: 0 0 24px rgba(255, 165, 0, 0.6); background-color: rgba(255, 165, 0, 0.15); }
     100% { box-shadow: 0 0 12px rgba(255, 165, 0, 0.4), 0 0 20px rgba(255, 165, 0, 0.2); background-color: rgba(255, 165, 0, 0.08); }
 }
-
-

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -18,7 +18,7 @@
     .selector-btn {
         flex: 0 0 auto;
         justify-content: center;
-        height: 30px;
+        height: 44px;
         padding: 0.25rem 0.35rem;
         min-width: 0;
         font-size: 0.8rem;
@@ -58,7 +58,7 @@
     .nav-btn {
         width: 44px;
         min-width: 44px;
-        height: 30px;
+        height: 44px;
         padding: 0.35rem;
         justify-content: center;
     }

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -17,11 +17,36 @@
 
     .selector-btn {
         flex: 0 0 auto;
-        justify-content: center;
+        justify-content: space-between;
+        gap: 4px;
         height: 44px;
-        padding: 0.25rem 0.35rem;
-        min-width: 0;
+        padding: 0 8px;
         font-size: 0.8rem;
+    }
+
+    .selector-btn > span {
+        flex: 1 1 auto;
+        min-width: 0;
+        text-align: center;
+    }
+
+    .selector-btn > svg {
+        width: 16px;
+        height: 16px;
+        flex: 0 0 16px;
+    }
+
+    #bookSelector {
+        min-width: 64px;
+    }
+
+    #chapterSelector,
+    #verseSelector {
+        min-width: 60px;
+    }
+
+    #translationSelectorBtn {
+        min-width: 76px;
     }
 
     .nav-content {
@@ -105,6 +130,30 @@
 
     .search-results {
         max-height: calc(80vh - 100px);
+    }
+}
+
+@media (max-width: 380px) {
+    .nav-content,
+    .passage-selector {
+        gap: 3px;
+    }
+
+    .selector-btn {
+        padding: 0 6px;
+    }
+
+    #bookSelector {
+        min-width: 58px;
+    }
+
+    #chapterSelector,
+    #verseSelector {
+        min-width: 56px;
+    }
+
+    #translationSelectorBtn {
+        min-width: 74px;
     }
 }
 

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -75,6 +75,7 @@
         justify-self: end;
     }
 
+    html.hide-chapter-arrows .passage-selector,
     body.hide-chapter-arrows .passage-selector {
         grid-column: 1 / -1;
         justify-self: center;
@@ -229,17 +230,25 @@
 
 .hidden { display: none !important; }
 
-/* Hide verse numbers when setting is off */
+html.hide-chapter-arrows #prevChapter,
+html.hide-chapter-arrows #nextChapter,
+body.hide-chapter-arrows #prevChapter,
+body.hide-chapter-arrows #nextChapter {
+    display: none !important;
+}
+
+html.hide-verse-numbers .passage-text .verse-num,
 body.hide-verse-numbers .passage-text .verse-num {
     display: none !important;
 }
 
-/* Verse-by-Verse Display */
+html.verse-by-verse-enabled .passage-text .verse,
 .verse-by-verse .verse {
     display: block;
     margin-bottom: 0.75rem;
 }
 
+html.verse-by-verse-enabled .passage-text .verse-num,
 .verse-by-verse .verse-num {
     display: inline;
     font-weight: 600;
@@ -247,44 +256,64 @@ body.hide-verse-numbers .passage-text .verse-num {
     margin-right: 0.5em;
 }
 
+html.verse-by-verse-enabled .passage-text p,
 .verse-by-verse p {
     margin: 0.5rem 0;
 }
 
+html.verse-by-verse-enabled .passage-text h3,
 .verse-by-verse h3 {
     margin-top: 1.5rem;
     margin-bottom: 0.75rem;
 }
 
-/* Reading font family */
+html.font-andika .passage-text,
+html.font-andika .passage,
+html.font-andika .search-result-content,
 body.font-andika .passage-text,
 body.font-andika .passage,
 body.font-andika .search-result-content {
     font-family: 'Andika', sans-serif;
 }
 
+html.font-ubuntu .passage-text,
+html.font-ubuntu .passage,
+html.font-ubuntu .search-result-content,
 body.font-ubuntu .passage-text,
 body.font-ubuntu .passage,
 body.font-ubuntu .search-result-content {
     font-family: 'Ubuntu', sans-serif;
 }
 
+html.font-opendyslexic3 .passage-text,
+html.font-opendyslexic3 .passage,
+html.font-opendyslexic3 .search-result-content,
 body.font-opendyslexic3 .passage-text,
 body.font-opendyslexic3 .passage,
 body.font-opendyslexic3 .search-result-content {
     font-family: 'OpenDyslexic3', sans-serif;
 }
 
+html.font-ia-quattro .passage-text,
+html.font-ia-quattro .passage,
+html.font-ia-quattro .search-result-content,
 body.font-ia-quattro .passage-text,
 body.font-ia-quattro .passage,
 body.font-ia-quattro .search-result-content {
     font-family: 'iA Writer Quattro S', sans-serif;
 }
 
+html.font-adwaitasans .passage-text,
+html.font-adwaitasans .passage,
+html.font-adwaitasans .search-result-content,
 body.font-adwaitasans .passage-text,
 body.font-adwaitasans .passage,
 body.font-adwaitasans .search-result-content {
     font-family: 'Adwaita Sans', sans-serif;
+}
+
+html .passage-text {
+    font-size: var(--startup-passage-font-size, 20px);
 }
 
 /* ================================

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -201,7 +201,7 @@
 
 .modal-body::-webkit-scrollbar,
 .modal-bottom-sheet .modal-body::-webkit-scrollbar {
-    width: 8px;
+    width: 12px;
 }
 
 .modal-body::-webkit-scrollbar-track,
@@ -211,10 +211,11 @@
 
 .modal-body::-webkit-scrollbar-thumb,
 .modal-bottom-sheet .modal-body::-webkit-scrollbar-thumb {
+    min-height: 36px;
     background-color: var(--border-neutral);
-    border: 2px solid transparent;
+    border: 3px solid transparent;
     border-radius: 999px;
-    background-clip: padding-box;
+    background-clip: content-box;
 }
 
 .modal-body::-webkit-scrollbar-thumb:hover,

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -16,24 +16,31 @@
     }
 
     .selector-btn {
-        padding: 0.25rem 0.5rem;
-        min-width: 56px;
+        flex: 1 1 0;
+        justify-content: center;
+        padding: 0.25rem 0.35rem;
+        min-width: 0;
         font-size: 0.8rem;
     }
 
     .nav-content {
+        grid-template-columns: 44px minmax(0, 1fr) 44px;
         gap: var(--spacing-xs);
+        padding-left: var(--spacing-sm);
+        padding-right: var(--spacing-sm);
     }
 
     .passage-selector {
-        flex: 1;
+        min-width: 0;
+        width: 100%;
         justify-content: center;
         gap: var(--spacing-xs);
     }
 
     .nav-btn {
-        padding: 0.35rem 0.7rem;
+        width: 44px;
         min-width: 44px;
+        padding: 0.35rem;
         justify-content: center;
     }
 

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -19,7 +19,7 @@
         flex: 0 0 auto;
         justify-content: center;
         gap: 4px;
-        height: 44px;
+        height: 33px;
         padding: 0 8px;
         font-size: 0.8rem;
     }
@@ -83,7 +83,7 @@
     .nav-btn {
         width: 44px;
         min-width: 44px;
-        height: 44px;
+        height: 33px;
         padding: 0.35rem;
         justify-content: center;
     }

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -51,8 +51,8 @@
 
     .nav-content {
         display: grid;
-        grid-template-columns: auto auto auto;
-        justify-content: center;
+        grid-template-columns: 44px minmax(0, 1fr) 44px;
+        width: 100%;
         gap: var(--spacing-xs);
         padding-left: var(--spacing-sm);
         padding-right: var(--spacing-sm);
@@ -60,19 +60,21 @@
 
     #prevChapter {
         grid-column: 1;
+        justify-self: start;
     }
 
     .passage-selector {
         grid-column: 2;
+        justify-self: center;
         flex: 0 1 auto;
         min-width: 0;
         width: auto;
-        justify-content: center;
         gap: var(--spacing-xs);
     }
 
     #nextChapter {
         grid-column: 3;
+        justify-self: end;
     }
 
     body.hide-chapter-arrows .passage-selector {
@@ -133,6 +135,34 @@
     }
 }
 
+@media (max-width: 480px) {
+    .selector-btn {
+        flex-direction: column;
+        justify-content: center;
+        gap: 1px;
+        padding: 3px 7px 2px;
+    }
+
+    .selector-btn > span {
+        flex: 0 0 auto;
+        line-height: 1;
+    }
+
+    .selector-btn > svg {
+        width: 14px;
+        height: 14px;
+        flex-basis: 14px;
+    }
+
+    .passage-title {
+        font-size: 1.25rem;
+    }
+
+    .book-grid {
+        grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+    }
+}
+
 @media (max-width: 380px) {
     .nav-content,
     .passage-selector {
@@ -140,7 +170,8 @@
     }
 
     .selector-btn {
-        padding: 0 6px;
+        padding-left: 6px;
+        padding-right: 6px;
     }
 
     #bookSelector {
@@ -154,16 +185,6 @@
 
     #translationSelectorBtn {
         min-width: 74px;
-    }
-}
-
-@media (max-width: 480px) {
-    .passage-title {
-        font-size: 1.25rem;
-    }
-
-    .book-grid {
-        grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
     }
 }
 

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -30,20 +30,8 @@
         text-align: center;
     }
 
-    #bookSelector > svg,
-    #chapterSelector > svg,
-    #verseSelector > svg {
+    .selector-btn > svg {
         display: none;
-    }
-
-    #translationSelectorBtn {
-        justify-content: space-between;
-    }
-
-    #translationSelectorBtn > svg {
-        width: 16px;
-        height: 16px;
-        flex: 0 0 16px;
     }
 
     #bookSelector {

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -16,8 +16,9 @@
     }
 
     .selector-btn {
-        flex: 1 1 0;
+        flex: 0 0 auto;
         justify-content: center;
+        height: 30px;
         padding: 0.25rem 0.35rem;
         min-width: 0;
         font-size: 0.8rem;
@@ -25,7 +26,8 @@
 
     .nav-content {
         display: grid;
-        grid-template-columns: 44px minmax(0, 1fr) 44px;
+        grid-template-columns: auto auto auto;
+        justify-content: center;
         gap: var(--spacing-xs);
         padding-left: var(--spacing-sm);
         padding-right: var(--spacing-sm);
@@ -37,8 +39,9 @@
 
     .passage-selector {
         grid-column: 2;
+        flex: 0 1 auto;
         min-width: 0;
-        width: 100%;
+        width: auto;
         justify-content: center;
         gap: var(--spacing-xs);
     }
@@ -49,11 +52,13 @@
 
     body.hide-chapter-arrows .passage-selector {
         grid-column: 1 / -1;
+        justify-self: center;
     }
 
     .nav-btn {
         width: 44px;
         min-width: 44px;
+        height: 30px;
         padding: 0.35rem;
         justify-content: center;
     }

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -192,6 +192,35 @@
     #currentBook .book-full { display: inline; }
 }
 
+/* Modal scrollbars */
+.modal-body,
+.modal-bottom-sheet .modal-body {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-neutral) transparent;
+}
+
+.modal-body::-webkit-scrollbar,
+.modal-bottom-sheet .modal-body::-webkit-scrollbar {
+    width: 8px;
+}
+
+.modal-body::-webkit-scrollbar-track,
+.modal-bottom-sheet .modal-body::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.modal-body::-webkit-scrollbar-thumb,
+.modal-bottom-sheet .modal-body::-webkit-scrollbar-thumb {
+    background-color: var(--border-neutral);
+    border: 2px solid transparent;
+    border-radius: 999px;
+    background-clip: padding-box;
+}
+
+.modal-body::-webkit-scrollbar-thumb:hover,
+.modal-bottom-sheet .modal-body::-webkit-scrollbar-thumb:hover {
+    background-color: var(--text-muted);
+}
 
 /* ================================
    11. UTILITY CLASSES
@@ -256,8 +285,6 @@ body.font-adwaitasans .passage,
 body.font-adwaitasans .search-result-content {
     font-family: 'Adwaita Sans', sans-serif;
 }
-
-
 
 /* ================================
    12. PRINT STYLES

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -75,7 +75,7 @@
         justify-self: end;
     }
 
-    html.hide-chapter-arrows .passage-selector,
+    html.hide-chapter-arrows:not(:has(body[data-app-ready="true"])) .passage-selector,
     body.hide-chapter-arrows .passage-selector {
         grid-column: 1 / -1;
         justify-self: center;
@@ -230,25 +230,27 @@
 
 .hidden { display: none !important; }
 
-html.hide-chapter-arrows #prevChapter,
-html.hide-chapter-arrows #nextChapter,
+html.hide-chapter-arrows:not(:has(body[data-app-ready="true"])) #prevChapter,
+html.hide-chapter-arrows:not(:has(body[data-app-ready="true"])) #nextChapter,
 body.hide-chapter-arrows #prevChapter,
 body.hide-chapter-arrows #nextChapter {
     display: none !important;
 }
 
-html.hide-verse-numbers .passage-text .verse-num,
+html.hide-verse-numbers:not(:has(body[data-app-ready="true"])) .passage-text .verse-num,
 body.hide-verse-numbers .passage-text .verse-num {
     display: none !important;
 }
 
-html.verse-by-verse-enabled .passage-text .verse,
+html.verse-by-verse-enabled:not(:has(body[data-app-ready="true"])) .passage-text .verse,
+body.verse-by-verse-mode .passage-text .verse,
 .verse-by-verse .verse {
-    display: block;
+    display: block !important;
     margin-bottom: 0.75rem;
 }
 
-html.verse-by-verse-enabled .passage-text .verse-num,
+html.verse-by-verse-enabled:not(:has(body[data-app-ready="true"])) .passage-text .verse-num,
+body.verse-by-verse-mode .passage-text .verse-num,
 .verse-by-verse .verse-num {
     display: inline;
     font-weight: 600;
@@ -256,12 +258,14 @@ html.verse-by-verse-enabled .passage-text .verse-num,
     margin-right: 0.5em;
 }
 
-html.verse-by-verse-enabled .passage-text p,
+html.verse-by-verse-enabled:not(:has(body[data-app-ready="true"])) .passage-text p,
+body.verse-by-verse-mode .passage-text p,
 .verse-by-verse p {
     margin: 0.5rem 0;
 }
 
-html.verse-by-verse-enabled .passage-text h3,
+html.verse-by-verse-enabled:not(:has(body[data-app-ready="true"])) .passage-text h3,
+body.verse-by-verse-mode .passage-text h3,
 .verse-by-verse h3 {
     margin-top: 1.5rem;
     margin-bottom: 0.75rem;

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -24,17 +24,31 @@
     }
 
     .nav-content {
+        display: grid;
         grid-template-columns: 44px minmax(0, 1fr) 44px;
         gap: var(--spacing-xs);
         padding-left: var(--spacing-sm);
         padding-right: var(--spacing-sm);
     }
 
+    #prevChapter {
+        grid-column: 1;
+    }
+
     .passage-selector {
+        grid-column: 2;
         min-width: 0;
         width: 100%;
         justify-content: center;
         gap: var(--spacing-xs);
+    }
+
+    #nextChapter {
+        grid-column: 3;
+    }
+
+    body.hide-chapter-arrows .passage-selector {
+        grid-column: 1 / -1;
     }
 
     .nav-btn {

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -17,7 +17,7 @@
 
     .selector-btn {
         flex: 0 0 auto;
-        justify-content: space-between;
+        justify-content: center;
         gap: 4px;
         height: 44px;
         padding: 0 8px;
@@ -30,7 +30,17 @@
         text-align: center;
     }
 
-    .selector-btn > svg {
+    #bookSelector > svg,
+    #chapterSelector > svg,
+    #verseSelector > svg {
+        display: none;
+    }
+
+    #translationSelectorBtn {
+        justify-content: space-between;
+    }
+
+    #translationSelectorBtn > svg {
         width: 16px;
         height: 16px;
         flex: 0 0 16px;
@@ -136,24 +146,6 @@
 }
 
 @media (max-width: 480px) {
-    .selector-btn {
-        flex-direction: column;
-        justify-content: center;
-        gap: 1px;
-        padding: 3px 7px 2px;
-    }
-
-    .selector-btn > span {
-        flex: 0 0 auto;
-        line-height: 1;
-    }
-
-    .selector-btn > svg {
-        width: 14px;
-        height: 14px;
-        flex-basis: 14px;
-    }
-
     .passage-title {
         font-size: 1.25rem;
     }

--- a/events.js
+++ b/events.js
@@ -67,9 +67,7 @@ function injectModal(html) {
 
 function teardown(modal, app) {
     app.closeModal(modal);
-    // Let the closing animation finish before removing
     modal.addEventListener('transitionend', () => modal.remove(), { once: true });
-    // Fallback if no transition fires
     setTimeout(() => { if (modal.isConnected) modal.remove(); }, 400);
 }
 
@@ -101,66 +99,52 @@ function openChangePasswordModal(app) {
     });
 }
 
+function syncReadingDisplay(app) {
+    document.body.classList.toggle('hide-verse-numbers', !app.state.showVerseNumbers);
+    document.body.classList.toggle('hide-chapter-arrows', !app.state.showChapterArrows);
+    document.body.classList.toggle('verse-by-verse-mode', !!app.state.verseByVerse);
+
+    for (const panel of document.querySelectorAll('#passageText, #swipePrev, #swipeNext')) {
+        panel.classList.toggle('verse-by-verse', !!app.state.verseByVerse);
+    }
+}
+
 /**
  * @param {object} app - BibleApp instance
  */
 export function attachEventListeners(app) {
-    // ── Search ───────────────────────────────────────────────────────────────
     app.searchToggleBtn?.addEventListener('click', () => app.toggleSearch());
     app.closeSearchBtn?.addEventListener('click',  () => app.closeSearch());
     app.searchInput?.addEventListener('input',     (e) => app.handleSearch(e.target.value, 'type'));
     app.searchInput?.addEventListener('keydown',   (e) => app.handleSearchKeydown(e));
-    // iOS/Android: paste does not reliably fire `input`; read value after DOM settles.
     app.searchInput?.addEventListener('paste',     ()  => setTimeout(() => app.handleSearch(app.searchInput.value, 'paste'), 0));
 
-    // Megasearch toggle:
-    // ON  — run a supplemental pass against cached translations immediately.
-    // OFF — re-run the active-translation-only search to strip supplemental results.
     document.getElementById('megasearchToggle')?.addEventListener('change', (e) => {
         const query = app.searchLastQuery || '';
         if (e.target.checked) {
             if (query.trim().length >= 3 && app.currentSearchResults?.length > 0) {
                 runMegasearch(app, query);
             }
-        } else {
-            if (query.trim().length > 0) {
-                performKeywordSearch(app, query);
-            }
+        } else if (query.trim().length > 0) {
+            performKeywordSearch(app, query);
         }
     });
 
-    // ── Navigation ──────────────────────────────────────────────────────────
     app.prevChapterBtn?.addEventListener('click',  () => app.navigateChapter(-1));
     app.nextChapterBtn?.addEventListener('click',  () => app.navigateChapter(1));
     app.bookSelector?.addEventListener('click',    () => app.openBookModal());
     app.chapterSelector?.addEventListener('click', () => app.openChapterModal());
     app.verseSelector?.addEventListener('click',   () => app.openVerseModal());
 
-    // Phase 3 three-panel drag-follow swipe navigation.
-    // Replaces the Phase 1/2 touchstart+touchend handler that was inline here.
-    // initSwipe() wraps #passageText in a clipping viewport and pre-renders
-    // adjacent panels after every loadPassage() resolves via
-    // app.swipe.syncAdjacentPanels() (called from app.loadPassage).
     initSwipe(app);
 
-    // ── Translation badge (nav) ──────────────────────────────────────────────
     app.translationSelectorBtn?.addEventListener('click', () => app.openTranslationModal());
-
-    // ── Copy passage ─────────────────────────────────────────────────────────
     document.getElementById('copyPassage')?.addEventListener('click', () => app.copyPassage());
 
-    // ── Verse tap-to-select ──────────────────────────────────────────────────
-    // Delegated to #swipeViewport (the stable wrapper) rather than app.passageText,
-    // because app.passageText is reassigned to a new DOM node on every swipe commit.
-    // Attaching to passageText directly would break verse selection after any swipe.
-    // touch-action:manipulation on .verse (set in CSS) eliminates the 300ms tap
-    // delay on mobile without disabling scroll.
-    // Tapping the already-selected verse deselects it.
     const verseClickTarget = document.getElementById('swipeViewport') ?? app.passageText;
     verseClickTarget?.addEventListener('click', (e) => {
         const verse = e.target.closest('.verse');
         if (!verse) return;
-        // Ignore clicks that originated inside the tool tray or trigger.
         if (e.target.closest('.verse-tools-tray, .verse-tools-trigger')) return;
         const num = parseInt(verse.dataset.verse, 10);
         if (!num) return;
@@ -172,7 +156,6 @@ export function attachEventListeners(app) {
         }
     });
 
-    // ── Modals: late-cached elements ─────────────────────────────────────────
     app.referencesModal        = document.getElementById('referencesModal');
     app.closeReferencesModal   = document.getElementById('closeReferencesModal');
     app.footnotesSection       = document.getElementById('footnotesSection');
@@ -180,7 +163,6 @@ export function attachEventListeners(app) {
     app.crossReferencesSection = document.getElementById('crossReferencesSection');
     app.crossReferencesContent = document.getElementById('crossReferencesContent');
 
-    // Backdrop-click closes any modal
     [
         app.bookModal, app.chapterModal, app.verseModal,
         app.settingsModal, app.loginModal,
@@ -202,17 +184,30 @@ export function attachEventListeners(app) {
 
     attachDragToResize(app);
 
-    // ── Settings toggles ─────────────────────────────────────────────────────
+    app.verseNumbersToggle?.addEventListener('input', (e) => {
+        app.state.showVerseNumbers = e.currentTarget.checked;
+        syncReadingDisplay(app);
+    });
     app.verseNumbersToggle?.addEventListener('change', () => app.toggleSetting('showVerseNumbers'));
-    app.headingsToggle?.addEventListener('change',     () => app.toggleSetting('showHeadings'));
-    app.footnotesToggle?.addEventListener('change',    () => app.toggleSetting('showFootnotes'));
-    app.chapterArrowsToggle?.addEventListener('change',() => app.toggleSetting('showChapterArrows'));
+
+    app.headingsToggle?.addEventListener('change', () => app.toggleSetting('showHeadings'));
+    app.footnotesToggle?.addEventListener('change', () => app.toggleSetting('showFootnotes'));
+
+    app.chapterArrowsToggle?.addEventListener('input', (e) => {
+        app.state.showChapterArrows = e.currentTarget.checked;
+        syncReadingDisplay(app);
+    });
+    app.chapterArrowsToggle?.addEventListener('change', () => app.toggleSetting('showChapterArrows'));
 
     app.crossReferencesToggle = document.getElementById('crossReferencesToggle');
     app.crossReferencesToggle?.addEventListener('change', () => app.toggleSetting('showCrossReferences'));
 
-    app.verseByVerseToggle?.addEventListener('change',  () => app.toggleVerseByVerse());
-    app.fontSizeSlider?.addEventListener('input',  (e) => app.updateFontSize(e.target.value));
+    app.verseByVerseToggle?.addEventListener('input', (e) => {
+        app.state.verseByVerse = e.currentTarget.checked;
+        syncReadingDisplay(app);
+    });
+    app.verseByVerseToggle?.addEventListener('change', () => app.toggleVerseByVerse());
+    app.fontSizeSlider?.addEventListener('input', (e) => app.updateFontSize(e.target.value));
 
     const readingFontSelector = document.getElementById('readingFontSelector');
     if (readingFontSelector) {
@@ -230,14 +225,11 @@ export function attachEventListeners(app) {
         });
     }
 
-    // Settings <select> still works as a secondary route
     app.translationSelector?.addEventListener('change', async (e) => app.changeTranslation(e.target.value));
 
-    // ── Theme ─────────────────────────────────────────────────────────────────
     document.getElementById('themeSelector')?.addEventListener('change', (e) => changeColorTheme(app, e.target.value));
     document.getElementById('lightModeSelect')?.addEventListener('change', (e) => setLightMode(app, e.target.value));
 
-    // ── Auth ──────────────────────────────────────────────────────────────────
     document.getElementById('userBtn')?.addEventListener('click', () => app.handleUserButtonClick());
     document.getElementById('changeEmailBtn')?.addEventListener('click', () => { app.closeModal(app.userMenuModal); openChangeEmailModal(app); });
     document.getElementById('changePasswordBtn')?.addEventListener('click', () => { app.closeModal(app.userMenuModal); openChangePasswordModal(app); });
@@ -267,19 +259,15 @@ export function attachEventListeners(app) {
     app.closeSignupModal?.addEventListener('click',   () => app.closeModal(app.signupModal));
     app.closeUserMenuModal?.addEventListener('click', () => app.closeModal(app.userMenuModal));
 
-    // ── Scroll (chrome hide/show + position save) ────────────────────────────
     window.addEventListener('scroll', () => {
         app.handleChromeScroll();
         clearTimeout(app.scrollTimeout);
         app.scrollTimeout = setTimeout(() => app.saveReadingPosition(), 500);
     }, { passive: true });
 
-    // ── Keyboard ──────────────────────────────────────────────────────────────
     document.addEventListener('keydown', (e) => app.handleKeyboardShortcuts(e));
-    // Live-update appearance when OS dark/light mode changes
     window.matchMedia('(prefers-color-scheme: light)')
         .addEventListener('change', () => {
             if (app.state.lightMode === 'system') applyLightMode('system');
         });
-
 }

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
 			if (isLight) el.classList.add('light-mode');
 		}());
 	</script>
+	<script src="prepaint-settings.js"></script>
 	<link rel="manifest" href="./site.webmanifest" />
 	<link rel="apple-touch-icon" href="./apple-touch-icon.png" />
 	<link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png" />

--- a/prepaint-settings.js
+++ b/prepaint-settings.js
@@ -1,0 +1,32 @@
+(function () {
+    var root = document.documentElement;
+
+    function get(key) {
+        try { return localStorage.getItem(key); } catch (_) { return null; }
+    }
+
+    function readBool(key, fallback) {
+        var value = get(key);
+        if (value === 'true') return true;
+        if (value === 'false') return false;
+        return fallback;
+    }
+
+    if (!readBool('showVerseNumbers', true)) root.classList.add('hide-verse-numbers');
+    if (!readBool('showChapterArrows', false)) root.classList.add('hide-chapter-arrows');
+    if (readBool('verseByVerse', false)) root.classList.add('verse-by-verse-enabled');
+
+    var fontClasses = {
+        andika: 'font-andika',
+        ubuntu: 'font-ubuntu',
+        opendyslexic3: 'font-opendyslexic3',
+        retrocide: 'font-retrocide',
+        'ia-quattro': 'font-ia-quattro',
+        adwaitasans: 'font-adwaitasans'
+    };
+    var fontClass = fontClasses[get('readingFont') || 'gentium'];
+    if (fontClass) root.classList.add(fontClass);
+
+    var size = parseInt(get('fontSize') || '20', 10);
+    root.style.setProperty('--startup-passage-font-size', Number.isFinite(size) ? size + 'px' : '20px');
+}());


### PR DESCRIPTION
## Summary

This PR promotes the current `exp` work into `dev` and includes the mobile navigation, modal interaction, scrollbar, and reading settings improvements completed so far.

## Mobile navigation

- Centered the passage selector group correctly when chapter arrows are visible.
- Kept chapter arrows fixed near the left and right screen edges for easier reach.
- Restored compact selector widths instead of stretching controls across the row.
- Standardized selector and chapter arrow heights.
- Reduced mobile control height to 33px after testing the larger 44px version.
- Removed dropdown chevrons from the book, chapter, verse, and translation buttons on mobile.
- Improved internal label alignment and responsive spacing on narrow screens.
- Preserved centered selectors when chapter arrows are hidden.

## Reading settings

- Fixed verse number visibility toggling.
- Fixed verse by verse display so each verse renders on its own line.
- Fixed chapter arrow visibility toggling.
- Added prepaint settings support to avoid startup flashes for verse numbers, chapter arrows, verse by verse mode, reading font, and font size.
- Prevented stale prepaint classes on `<html>` from overriding live settings after initialization.
- Synchronized reading display state across the current passage and adjacent swipe panels.

## Modal and interaction improvements

- Disabled double tap zoom while preserving normal scrolling and pinch zoom.
- Aligned the square verse tool action row with the circular action row below it.
- Added thin, theme matched modal scrollbars.
- Made modal scrollbar tracks transparent.
- Added inset spacing so scrollbar thumbs do not touch the modal edge.
- Rounded scrollbar thumbs and added hover feedback.

## Files changed

- `css/base.css`
- `css/interactions.css`
- `css/utilities.css`
- `events.js`
- `index.html`
- `prepaint-settings.js`

## Testing notes

- Confirm mobile navigation remains centered at narrow widths with chapter arrows both enabled and disabled.
- Confirm chapter arrows remain near the screen edges.
- Confirm verse numbers toggle immediately.
- Confirm verse by verse mode places every verse on a separate line.
- Confirm chapter arrow visibility toggles immediately.
- Confirm modal scrollbar thumbs are rounded and inset from the edge.
- Confirm pinch zoom still works while double tap zoom does not.