### PR TITLE
Revert dev swipe test changes

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -72,11 +72,6 @@ body:not(.no-color-transition) *::after {
     }
 }
 
-#swipeViewport {
-    touch-action: pan-y; /*Vertical movement is still normal page scrolling.*/
-    overscroll-behavior-x: contain; /*Reduces horizontal browser-level overscroll behavior during side swipes.*\
-}
-
 /* During an active swipe drag the three panel elements must track the finger
    with zero latency. The wildcard transition above would otherwise ease every
    translateX write, causing jitter and preventing adjacent panels from sitting

--- a/swipe.js
+++ b/swipe.js
@@ -300,30 +300,27 @@ export function initSwipe(app) {
             if (Math.abs(dx) < 6 && Math.abs(dy) < 6) return;
 
             if (Math.abs(dy) > Math.abs(dx) * TAN_30 || Math.abs(dy) > Math.abs(dx)) {
-                app._dbgUserAction?.(`swipe vetoed: dx=${Math.round(dx)} dy=${Math.round(dy)}`);
                 _vetoed = true;
                 return;
             }
             _tracking = true;
             viewport.classList.add('swiping');
-        
+
             app.passageText.style.position = 'absolute';
             app.passageText.style.top      = '0';
             app.passageText.style.left     = '0';
             app.passageText.style.width    = '100%';
             viewport.style.height = app.passageText.offsetHeight + 'px';
         }
-        
+
         if (!e.cancelable) {
-            app._dbgUserAction?.('swipe canceled: touchmove not cancelable');
-        
             _cleanupDrag();
-        
+
             const W = vw();
             _setTranslateX(app.passageText, 0);
             _setTranslateX(app.swipe.prevPanel, -W);
             _setTranslateX(app.swipe.nextPanel, W);
-        
+
             _tracking = false;
             _vetoed = true;
             return;


### PR DESCRIPTION
Reverts the swipe test changes currently on dev so swipe investigation can continue on exp only.

This keeps branch protection intact and avoids force-pushing dev.