### PR TITLE
Run CodeQL on dev

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - exp
+      - dev
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
Allow CodeQL to run on dev so the dev-to-main PR can satisfy repository rules.