### PR TITLE
Run NASB95 integration

### DIFF
--- a/.github/nasb95-integration-trigger
+++ b/.github/nasb95-integration-trigger
@@ -1,0 +1,1 @@
+Run the validated NASB95 runtime integration.


### PR DESCRIPTION
Triggers the validated NASB95 runtime integration against the current exp branch. The workflow commits the runtime change directly to exp and removes itself after validation.