### PR TITLE
Retrigger NASB95 standard import

### DIFF
--- a/.github/nasb95-local-import.trigger
+++ b/.github/nasb95-local-import.trigger
@@ -1,1 +1,2 @@
 Import NASB95 into the standard translations directory.
+Retry through a merged pull request.


### PR DESCRIPTION
Creates a normal merged push touching the existing NASB95 import trigger so the trusted exp workflow can generate the translation under translations/NASB95, validate it, remove Firebase-only routing, and restore the workflow.